### PR TITLE
Add AVX512 support for BLAKE3 16-way parallel chunk hashing

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
 
   cmake-linux:
     name: CMake Linux (GCC)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -22,10 +22,83 @@ jobs:
       run: cmake --preset=ci-linux
 
     - name: Build
-      run: cmake --build build/ci-linux -j$(nproc)
+      run: cmake --build build/ci-linux -j"$(nproc)"
 
     - name: Run validation tests
       run: ./build/ci-linux/cryptest.exe v
+
+    - name: Run test vectors
+      run: ./build/ci-linux/cryptest.exe tv all
+
+  cmake-linux-gcc14:
+    name: CMake Linux (GCC 14)
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install GCC 14 and Ninja
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-14 g++-14 ninja-build
+
+    - name: Configure (GCC 14)
+      env:
+        CC: gcc-14
+        CXX: g++-14
+      run: cmake --preset=ci-linux
+
+    - name: Build
+      run: cmake --build build/ci-linux -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./build/ci-linux/cryptest.exe v
+
+    - name: Run test vectors
+      run: ./build/ci-linux/cryptest.exe tv all
+
+  cmake-linux-clang19:
+    name: CMake Linux (Clang 19)
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Clang 19 and Ninja
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-19 ninja-build
+
+    - name: Check CPU features
+      run: |
+        echo "=== CPU Information ==="
+        lscpu | grep -E "Model name|Flags"
+        echo ""
+        echo "=== AVX512 Flags ==="
+        if grep -q avx512f /proc/cpuinfo; then
+          echo "AVX512F: SUPPORTED"
+        else
+          echo "AVX512F: NOT SUPPORTED"
+        fi
+
+    - name: Configure (Clang 19)
+      env:
+        CC: clang-19
+        CXX: clang++-19
+      run: cmake --preset=ci-linux
+
+    - name: Build
+      run: cmake --build build/ci-linux -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./build/ci-linux/cryptest.exe v
+
+    - name: Run BLAKE3 benchmark
+      run: |
+        cd build/ci-linux
+        echo "=== BLAKE3 Benchmark ==="
+        ./cryptest.exe b 3 4.0 blake3
+        echo ""
 
     - name: Run test vectors
       run: ./build/ci-linux/cryptest.exe tv all
@@ -44,7 +117,7 @@ jobs:
       run: cmake --preset=ci-macos
 
     - name: Build
-      run: cmake --build build/ci-macos -j$(sysctl -n hw.ncpu)
+      run: cmake --build build/ci-macos -j"$(sysctl -n hw.ncpu)"
 
     - name: Run validation tests
       run: ./build/ci-macos/cryptest.exe v
@@ -73,7 +146,7 @@ jobs:
 
   cmake-no-asm:
     name: CMake No-ASM (Pure C++)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -85,7 +158,7 @@ jobs:
       run: cmake --preset=no-asm
 
     - name: Build
-      run: cmake --build build/no-asm -j$(nproc)
+      run: cmake --build build/no-asm -j"$(nproc)"
 
     - name: Run validation tests
       run: ./build/no-asm/cryptest.exe v
@@ -95,7 +168,7 @@ jobs:
 
   cmake-install:
     name: CMake Install Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -107,7 +180,7 @@ jobs:
       run: cmake --preset=install-test
 
     - name: Build
-      run: cmake --build build/install-test -j$(nproc)
+      run: cmake --build build/install-test -j"$(nproc)"
 
     - name: Install
       run: cmake --install build/install-test
@@ -156,7 +229,7 @@ jobs:
 
   makefile-linux-gcc:
     name: Makefile Linux GCC ${{ matrix.gcc-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -177,7 +250,7 @@ jobs:
         export CXX=g++-${{ matrix.gcc-version }}
         export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }}"
         make clean
-        make -j$(nproc)
+        make -j"$(nproc)"
 
     - name: Run validation tests
       run: ./cryptest.exe v
@@ -185,7 +258,7 @@ jobs:
     - name: Run test vectors
       run: ./cryptest.exe tv all
 
-  makefile-linux-clang:
+  makefile-linux-clang-old:
     name: Makefile Linux Clang ${{ matrix.clang-version }}
     runs-on: ubuntu-22.04
     strategy:
@@ -209,7 +282,37 @@ jobs:
         export CXX=clang++-${{ matrix.clang-version }}
         export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }}"
         make clean
-        make -j$(nproc)
+        make -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./cryptest.exe v
+
+    - name: Run test vectors
+      run: ./cryptest.exe tv all
+
+  makefile-linux-clang-new:
+    name: Makefile Linux Clang ${{ matrix.clang-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        clang-version: [18, 19]
+        cxx-standard: [14, 17, 20]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Clang ${{ matrix.clang-version }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-${{ matrix.clang-version }}
+
+    - name: Build library (C++${{ matrix.cxx-standard }})
+      run: |
+        export CXX=clang++-${{ matrix.clang-version }}
+        export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }}"
+        make clean
+        make -j"$(nproc)"
 
     - name: Run validation tests
       run: ./cryptest.exe v
@@ -232,7 +335,7 @@ jobs:
       run: |
         export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }} -stdlib=libc++"
         make clean
-        make -j$(sysctl -n hw.ncpu)
+        make -j"$(sysctl -n hw.ncpu)"
 
     - name: Run validation tests
       run: ./cryptest.exe v
@@ -272,7 +375,7 @@ jobs:
 
   sanitizers:
     name: Sanitizer ${{ matrix.sanitizer }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -281,16 +384,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install GCC 12
+    - name: Install GCC 13
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-12 g++-12
+        sudo apt-get install -y gcc-13 g++-13
 
     - name: Build with ${{ matrix.sanitizer }}
       run: |
-        export CXX=g++-12
+        export CXX=g++-13
         make clean
-        make ${{ matrix.sanitizer }} -j$(nproc)
+        make ${{ matrix.sanitizer }} -j"$(nproc)"
 
     - name: Run validation tests
       run: ./cryptest.exe v 2>&1 | tee validation.log
@@ -304,3 +407,46 @@ jobs:
 
     - name: Run test vectors
       run: ./cryptest.exe tv all
+
+  # =============================================================================
+  # AVX512 Testing
+  # =============================================================================
+
+  avx512-test:
+    name: AVX512 Feature Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check CPU features
+      run: |
+        echo "=== CPU Information ==="
+        lscpu | grep -E "Model name|Flags"
+        echo ""
+        echo "=== AVX512 Flags ==="
+        if grep -q avx512f /proc/cpuinfo; then
+          echo "AVX512F: SUPPORTED"
+        else
+          echo "AVX512F: NOT SUPPORTED"
+        fi
+        if grep -q avx512vl /proc/cpuinfo; then
+          echo "AVX512VL: SUPPORTED"
+        else
+          echo "AVX512VL: NOT SUPPORTED"
+        fi
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure
+      run: cmake --preset=ci-linux
+
+    - name: Build
+      run: cmake --build build/ci-linux -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./build/ci-linux/cryptest.exe v
+
+    - name: Run test vectors
+      run: ./build/ci-linux/cryptest.exe tv all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ if(
         set(aesni_flag "-xarch=aes")
         set(avx_flag "-xarch=avx")
         set(avx2_flag "-xarch=avx2")
+        set(avx512_flag "-xarch=avx512")
         set(shani_flag "-xarch=sha")
     else()
         set(sse2_flag "-msse2")
@@ -572,6 +573,7 @@ if(
         set(aesni_flag "-maes")
         set(avx_flag "-mavx")
         set(avx2_flag "-mavx2")
+        set(avx512_flag "-mavx512f;-mavx512vl")
         set(shani_flag "-msha")
     endif()
 
@@ -685,6 +687,17 @@ if(
             list(APPEND CRYPTOPP_SUN_LDFLAGS "${avx2_flag}")
         else()
             set(avx2_flag "")
+        endif()
+
+        check_compile_link_option("${avx512_flag}" CRYPTOPP_HAVE_AVX512
+                                  "${TEST_PROG_DIR}/test_x86_avx512.cpp"
+        )
+        if(CRYPTOPP_HAVE_AVX512)
+            # BLAKE3 AVX512 needs SSE4.1, AVX2 (for fallback) and AVX512
+            list(APPEND CRYPTOPP_BLAKE3_AVX512_FLAGS "${sse41_flag}" "${avx2_flag}" "${avx512_flag}")
+            list(APPEND CRYPTOPP_SUN_LDFLAGS "${avx512_flag}")
+        else()
+            set(avx512_flag "")
         endif()
 
         check_compile_link_option(${shani_flag} CRYPTOPP_HAVE_SHANI
@@ -1075,6 +1088,19 @@ else()
     set_source_files_properties(
         ${cryptopp_SOURCE_DIR}/src/hash/blake3_simd.cpp
         PROPERTIES COMPILE_OPTIONS "${CRYPTOPP_BLAKE3_AVX2_FLAGS}"
+    )
+endif()
+
+# BLAKE3 AVX512: Use /arch:AVX512 on MSVC for 16-way parallel hashing
+if(MSVC)
+    set_source_files_properties(
+        ${cryptopp_SOURCE_DIR}/src/hash/blake3_avx512.cpp
+        PROPERTIES COMPILE_OPTIONS "/arch:AVX512"
+    )
+else()
+    set_source_files_properties(
+        ${cryptopp_SOURCE_DIR}/src/hash/blake3_avx512.cpp
+        PROPERTIES COMPILE_OPTIONS "${CRYPTOPP_BLAKE3_AVX512_FLAGS}"
     )
 endif()
 

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -54,6 +54,7 @@ set(cryptopp_SOURCES_HASH
     src/hash/blake2s_simd.cpp
     src/hash/blake3.cpp
     src/hash/blake3_simd.cpp
+    src/hash/blake3_avx512.cpp
     src/hash/crc.cpp
     src/hash/crc_simd.cpp
     src/hash/keccak.cpp

--- a/cryptest.dat
+++ b/cryptest.dat
@@ -1,0 +1,1 @@
+¥¯Ï'ý…ÒQì†ð¹št«.öæ¹Ÿ{oŠû¤´ðêý$a‡ú‚É®«?±ëˆ÷¬FRUüGaÜˆ›ãFý¹í›ý±©I¥vì6³?šz\Vaè’åâ¨U.ÍÎÑÄ¹ÚBr!^ÔUÛ»kãå¸6[Ú ôïÜu3«ö>+Òfe—¬€„Sý$¬¬²p$òƒ­)Ò“Ž‡'ã}I¸†•n.Š{¸Óµ±4)¡ùÌ¬_8F¼'5Ìm^å‘uæ'02Túé;™CõúªyÁß§‰5îØãIâ5ìÃX(&ÌYsÌ£•gÁK-oãih-üÄ>zÒòò"Tñ%

--- a/cryptlib.vcxproj
+++ b/cryptlib.vcxproj
@@ -187,6 +187,12 @@
     <ClCompile Include="src\hash\blake2b_simd.cpp" />
     <ClCompile Include="src\hash\blake3.cpp" />
     <ClCompile Include="src\hash\blake3_simd.cpp" />
+    <ClCompile Include="src\hash\blake3_avx512.cpp">
+      <!-- AVX512 requires VS2019 16.4+ (v142+) -->
+      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition=" '$(PlatformToolset)' == 'v100' Or '$(PlatformToolset)' == 'v110' Or '$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'v140' Or '$(PlatformToolset)' == 'v141' ">true</ExcludedFromBuild>
+      <AdditionalOptions>/arch:AVX512 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="src\symmetric\blowfish.cpp" />
     <ClCompile Include="src\random\blumshub.cpp" />
     <ClCompile Include="src\symmetric\camellia.cpp" />

--- a/cryptlib.vcxproj.filters
+++ b/cryptlib.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="blake3_simd.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="blake3_avx512.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="blowfish.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/include/cryptopp/config_asm.h
+++ b/include/cryptopp/config_asm.h
@@ -167,6 +167,25 @@
 #define CRYPTOPP_AVX2_AVAILABLE 1
 #endif
 
+// AVX512F is different from AVX512 generally. Different different different.
+// Requires GCC 4.9, MSVC 2017 (15.0), Clang 3.9, Intel i16
+// AVX512 is only available on 64-bit x86 (x64), not 32-bit x86
+#if !defined(CRYPTOPP_DISABLE_AVX512) && defined(CRYPTOPP_AVX2_AVAILABLE) && \
+	(CRYPTOPP_BOOL_X64 || defined(__x86_64__)) && \
+	(defined(__AVX512F__) || (CRYPTOPP_MSC_VERSION >= 1910) || \
+	(CRYPTOPP_GCC_VERSION >= 40900) || (__INTEL_COMPILER >= 1600) || \
+	(CRYPTOPP_LLVM_CLANG_VERSION >= 30900) || (CRYPTOPP_APPLE_CLANG_VERSION >= 80000))
+#define CRYPTOPP_AVX512F_AVAILABLE 1
+#endif
+
+// AVX512VL provides 256-bit and 128-bit versions of AVX512 instructions
+#if !defined(CRYPTOPP_DISABLE_AVX512) && defined(CRYPTOPP_AVX512F_AVAILABLE) && \
+	(defined(__AVX512VL__) || (CRYPTOPP_MSC_VERSION >= 1910) || \
+	(CRYPTOPP_GCC_VERSION >= 40900) || (__INTEL_COMPILER >= 1600) || \
+	(CRYPTOPP_LLVM_CLANG_VERSION >= 30900) || (CRYPTOPP_APPLE_CLANG_VERSION >= 80000))
+#define CRYPTOPP_AVX512VL_AVAILABLE 1
+#endif
+
 // Guessing at SHA for SunCC. Its not in Sun Studio 12.6. Also see
 // http://stackoverflow.com/questions/45872180/which-xarch-for-sha-extensions-on-solaris
 // Guessing for Intel ICPC. A slide deck says SHA support is in version 16.0-beta
@@ -218,6 +237,8 @@
 #define CONST_M128_CAST(x) ((const __m128i *)(const void *)(x))
 #define M256_CAST(x) ((__m256i *)(void *)(x))
 #define CONST_M256_CAST(x) ((const __m256i *)(const void *)(x))
+#define M512_CAST(x) ((__m512i *)(void *)(x))
+#define CONST_M512_CAST(x) ((const __m512i *)(const void *)(x))
 
 #endif  // CRYPTOPP_DISABLE_ASM
 

--- a/include/cryptopp/cpu.h
+++ b/include/cryptopp/cpu.h
@@ -94,6 +94,8 @@ extern CRYPTOPP_DLL bool g_hasAESNI;
 extern CRYPTOPP_DLL bool g_hasCLMUL;
 extern CRYPTOPP_DLL bool g_hasAVX;
 extern CRYPTOPP_DLL bool g_hasAVX2;
+extern CRYPTOPP_DLL bool g_hasAVX512F;
+extern CRYPTOPP_DLL bool g_hasAVX512VL;
 extern CRYPTOPP_DLL bool g_hasSHA;
 extern CRYPTOPP_DLL bool g_hasADX;
 extern CRYPTOPP_DLL bool g_isP4;
@@ -282,6 +284,39 @@ inline bool HasAVX2()
 	if (!g_x86DetectionDone)
 		DetectX86Features();
 	return g_hasAVX2;
+#else
+	return false;
+#endif
+}
+
+/// \brief Determine AVX512F availability
+/// \return true if AVX512F is determined to be available, false otherwise
+/// \details HasAVX512F() is a runtime check performed using CPUID
+/// \since Crypto++ 9.0
+/// \note This function is only available on Intel IA-32 platforms
+inline bool HasAVX512F()
+{
+#if CRYPTOPP_AVX512F_AVAILABLE
+	if (!g_x86DetectionDone)
+		DetectX86Features();
+	return g_hasAVX512F;
+#else
+	return false;
+#endif
+}
+
+/// \brief Determine AVX512VL availability
+/// \return true if AVX512VL is determined to be available, false otherwise
+/// \details HasAVX512VL() is a runtime check performed using CPUID.
+///  AVX512VL provides 256-bit and 128-bit versions of AVX512 instructions.
+/// \since Crypto++ 9.0
+/// \note This function is only available on Intel IA-32 platforms
+inline bool HasAVX512VL()
+{
+#if CRYPTOPP_AVX512VL_AVAILABLE
+	if (!g_x86DetectionDone)
+		DetectX86Features();
+	return g_hasAVX512VL;
 #else
 	return false;
 #endif

--- a/src/hash/blake3_avx512.cpp
+++ b/src/hash/blake3_avx512.cpp
@@ -1,0 +1,456 @@
+// blake3_avx512.cpp - written and placed in the public domain by
+//                     Colin Brown.
+//
+//    This source file uses intrinsics to gain access to AVX512
+//    instructions for 16-way parallel chunk hashing. A separate
+//    source file is needed because additional CXXFLAGS are required
+//    to enable the appropriate instruction sets.
+//
+//    AVX512 implementation based on the BLAKE3 team's reference at
+//    https://github.com/BLAKE3-team/BLAKE3 (public domain/CC0 1.0).
+
+#include <cryptopp/pch.h>
+#include <cryptopp/config.h>
+#include <cryptopp/misc.h>
+#include <cryptopp/blake3.h>
+
+#if (CRYPTOPP_AVX512F_AVAILABLE) && (CRYPTOPP_AVX512VL_AVAILABLE)
+# include <immintrin.h>
+#endif
+
+// Squash MS LNK4221 and libtool warnings
+extern const char BLAKE3_AVX512_FNAME[] = __FILE__;
+
+NAMESPACE_BEGIN(CryptoPP)
+
+// BLAKE3 IV - same as SHA-256 (aligned in blake3.cpp)
+extern const word32 BLAKE3_IV[8];
+
+// Message schedule for BLAKE3 - 7 rounds
+extern const byte BLAKE3_MSG_SCHEDULE[7][16];
+
+// BLAKE3 constants
+static const size_t BLAKE3_BLOCK_LEN = 64;
+static const size_t BLAKE3_CHUNK_LEN = 1024;
+static const byte BLAKE3_CHUNK_START = 1;
+static const byte BLAKE3_CHUNK_END = 2;
+
+#if (CRYPTOPP_AVX512F_AVAILABLE) && (CRYPTOPP_AVX512VL_AVAILABLE)
+
+// AVX512 helper macros and functions
+#define LOADU512(p)    _mm512_loadu_si512((const __m512i *)(const void*)(p))
+#define STOREU512(p,r) _mm512_storeu_si512((__m512i *)(void*)(p), r)
+
+inline __m512i addv512(__m512i a, __m512i b) { return _mm512_add_epi32(a, b); }
+inline __m512i xorv512(__m512i a, __m512i b) { return _mm512_xor_si512(a, b); }
+inline __m512i set1_512(word32 x) { return _mm512_set1_epi32((int)x); }
+
+inline __m512i set16(word32 a, word32 b, word32 c, word32 d,
+                     word32 e, word32 f, word32 g, word32 h,
+                     word32 i, word32 j, word32 k, word32 l,
+                     word32 m, word32 n, word32 o, word32 p) {
+    return _mm512_setr_epi32((int)a, (int)b, (int)c, (int)d,
+                              (int)e, (int)f, (int)g, (int)h,
+                              (int)i, (int)j, (int)k, (int)l,
+                              (int)m, (int)n, (int)o, (int)p);
+}
+
+// Rotation by 16 bits using native AVX512 rotate instruction
+inline __m512i rot16_512(__m512i x) {
+    return _mm512_ror_epi32(x, 16);
+}
+
+// Rotation by 12 bits using native AVX512 rotate instruction
+inline __m512i rot12_512(__m512i x) {
+    return _mm512_ror_epi32(x, 12);
+}
+
+// Rotation by 8 bits using native AVX512 rotate instruction
+inline __m512i rot8_512(__m512i x) {
+    return _mm512_ror_epi32(x, 8);
+}
+
+// Rotation by 7 bits using native AVX512 rotate instruction
+inline __m512i rot7_512(__m512i x) {
+    return _mm512_ror_epi32(x, 7);
+}
+
+// Load message words from 16 blocks into 16 transposed vectors
+// Each output vector contains the same word position from each of 16 chunks
+inline void transpose_msg_vecs16(const byte *const *inputs, size_t block_offset,
+                                 __m512i out[16])
+{
+    // Load word i from all 16 inputs
+    for (int word = 0; word < 16; word++) {
+        size_t byte_offset = block_offset + word * sizeof(word32);
+        out[word] = _mm512_setr_epi32(
+            *(const int*)&inputs[0][byte_offset],
+            *(const int*)&inputs[1][byte_offset],
+            *(const int*)&inputs[2][byte_offset],
+            *(const int*)&inputs[3][byte_offset],
+            *(const int*)&inputs[4][byte_offset],
+            *(const int*)&inputs[5][byte_offset],
+            *(const int*)&inputs[6][byte_offset],
+            *(const int*)&inputs[7][byte_offset],
+            *(const int*)&inputs[8][byte_offset],
+            *(const int*)&inputs[9][byte_offset],
+            *(const int*)&inputs[10][byte_offset],
+            *(const int*)&inputs[11][byte_offset],
+            *(const int*)&inputs[12][byte_offset],
+            *(const int*)&inputs[13][byte_offset],
+            *(const int*)&inputs[14][byte_offset],
+            *(const int*)&inputs[15][byte_offset]);
+    }
+}
+
+// Perform one round of BLAKE3 compression on 16 parallel states
+inline void round_fn16(__m512i v[16], __m512i m[16], size_t r)
+{
+    // Column step - first half
+    v[0]  = addv512(v[0], m[BLAKE3_MSG_SCHEDULE[r][0]]);
+    v[1]  = addv512(v[1], m[BLAKE3_MSG_SCHEDULE[r][2]]);
+    v[2]  = addv512(v[2], m[BLAKE3_MSG_SCHEDULE[r][4]]);
+    v[3]  = addv512(v[3], m[BLAKE3_MSG_SCHEDULE[r][6]]);
+    v[0]  = addv512(v[0], v[4]);
+    v[1]  = addv512(v[1], v[5]);
+    v[2]  = addv512(v[2], v[6]);
+    v[3]  = addv512(v[3], v[7]);
+    v[12] = xorv512(v[12], v[0]);
+    v[13] = xorv512(v[13], v[1]);
+    v[14] = xorv512(v[14], v[2]);
+    v[15] = xorv512(v[15], v[3]);
+    v[12] = rot16_512(v[12]);
+    v[13] = rot16_512(v[13]);
+    v[14] = rot16_512(v[14]);
+    v[15] = rot16_512(v[15]);
+    v[8]  = addv512(v[8], v[12]);
+    v[9]  = addv512(v[9], v[13]);
+    v[10] = addv512(v[10], v[14]);
+    v[11] = addv512(v[11], v[15]);
+    v[4]  = xorv512(v[4], v[8]);
+    v[5]  = xorv512(v[5], v[9]);
+    v[6]  = xorv512(v[6], v[10]);
+    v[7]  = xorv512(v[7], v[11]);
+    v[4]  = rot12_512(v[4]);
+    v[5]  = rot12_512(v[5]);
+    v[6]  = rot12_512(v[6]);
+    v[7]  = rot12_512(v[7]);
+
+    // Column step - second half
+    v[0]  = addv512(v[0], m[BLAKE3_MSG_SCHEDULE[r][1]]);
+    v[1]  = addv512(v[1], m[BLAKE3_MSG_SCHEDULE[r][3]]);
+    v[2]  = addv512(v[2], m[BLAKE3_MSG_SCHEDULE[r][5]]);
+    v[3]  = addv512(v[3], m[BLAKE3_MSG_SCHEDULE[r][7]]);
+    v[0]  = addv512(v[0], v[4]);
+    v[1]  = addv512(v[1], v[5]);
+    v[2]  = addv512(v[2], v[6]);
+    v[3]  = addv512(v[3], v[7]);
+    v[12] = xorv512(v[12], v[0]);
+    v[13] = xorv512(v[13], v[1]);
+    v[14] = xorv512(v[14], v[2]);
+    v[15] = xorv512(v[15], v[3]);
+    v[12] = rot8_512(v[12]);
+    v[13] = rot8_512(v[13]);
+    v[14] = rot8_512(v[14]);
+    v[15] = rot8_512(v[15]);
+    v[8]  = addv512(v[8], v[12]);
+    v[9]  = addv512(v[9], v[13]);
+    v[10] = addv512(v[10], v[14]);
+    v[11] = addv512(v[11], v[15]);
+    v[4]  = xorv512(v[4], v[8]);
+    v[5]  = xorv512(v[5], v[9]);
+    v[6]  = xorv512(v[6], v[10]);
+    v[7]  = xorv512(v[7], v[11]);
+    v[4]  = rot7_512(v[4]);
+    v[5]  = rot7_512(v[5]);
+    v[6]  = rot7_512(v[6]);
+    v[7]  = rot7_512(v[7]);
+
+    // Diagonal step - first half
+    v[0]  = addv512(v[0], m[BLAKE3_MSG_SCHEDULE[r][8]]);
+    v[1]  = addv512(v[1], m[BLAKE3_MSG_SCHEDULE[r][10]]);
+    v[2]  = addv512(v[2], m[BLAKE3_MSG_SCHEDULE[r][12]]);
+    v[3]  = addv512(v[3], m[BLAKE3_MSG_SCHEDULE[r][14]]);
+    v[0]  = addv512(v[0], v[5]);
+    v[1]  = addv512(v[1], v[6]);
+    v[2]  = addv512(v[2], v[7]);
+    v[3]  = addv512(v[3], v[4]);
+    v[15] = xorv512(v[15], v[0]);
+    v[12] = xorv512(v[12], v[1]);
+    v[13] = xorv512(v[13], v[2]);
+    v[14] = xorv512(v[14], v[3]);
+    v[15] = rot16_512(v[15]);
+    v[12] = rot16_512(v[12]);
+    v[13] = rot16_512(v[13]);
+    v[14] = rot16_512(v[14]);
+    v[10] = addv512(v[10], v[15]);
+    v[11] = addv512(v[11], v[12]);
+    v[8]  = addv512(v[8], v[13]);
+    v[9]  = addv512(v[9], v[14]);
+    v[5]  = xorv512(v[5], v[10]);
+    v[6]  = xorv512(v[6], v[11]);
+    v[7]  = xorv512(v[7], v[8]);
+    v[4]  = xorv512(v[4], v[9]);
+    v[5]  = rot12_512(v[5]);
+    v[6]  = rot12_512(v[6]);
+    v[7]  = rot12_512(v[7]);
+    v[4]  = rot12_512(v[4]);
+
+    // Diagonal step - second half
+    v[0]  = addv512(v[0], m[BLAKE3_MSG_SCHEDULE[r][9]]);
+    v[1]  = addv512(v[1], m[BLAKE3_MSG_SCHEDULE[r][11]]);
+    v[2]  = addv512(v[2], m[BLAKE3_MSG_SCHEDULE[r][13]]);
+    v[3]  = addv512(v[3], m[BLAKE3_MSG_SCHEDULE[r][15]]);
+    v[0]  = addv512(v[0], v[5]);
+    v[1]  = addv512(v[1], v[6]);
+    v[2]  = addv512(v[2], v[7]);
+    v[3]  = addv512(v[3], v[4]);
+    v[15] = xorv512(v[15], v[0]);
+    v[12] = xorv512(v[12], v[1]);
+    v[13] = xorv512(v[13], v[2]);
+    v[14] = xorv512(v[14], v[3]);
+    v[15] = rot8_512(v[15]);
+    v[12] = rot8_512(v[12]);
+    v[13] = rot8_512(v[13]);
+    v[14] = rot8_512(v[14]);
+    v[10] = addv512(v[10], v[15]);
+    v[11] = addv512(v[11], v[12]);
+    v[8]  = addv512(v[8], v[13]);
+    v[9]  = addv512(v[9], v[14]);
+    v[5]  = xorv512(v[5], v[10]);
+    v[6]  = xorv512(v[6], v[11]);
+    v[7]  = xorv512(v[7], v[8]);
+    v[4]  = xorv512(v[4], v[9]);
+    v[5]  = rot7_512(v[5]);
+    v[6]  = rot7_512(v[6]);
+    v[7]  = rot7_512(v[7]);
+    v[4]  = rot7_512(v[4]);
+}
+
+// Transpose 16 state vectors back to 16 CVs
+// h_vecs[i] contains word i from each of 16 chunks (transposed form)
+// We need to output 16 contiguous 32-byte CVs (untransposed)
+inline void transpose_vecs16_out(__m512i h_vecs[8], byte *out)
+{
+    // Use scatter/gather approach or manual extraction
+    // For each chunk, we need to extract its CV from all 8 h_vecs
+    alignas(64) word32 temp[8][16];
+
+    // Store transposed data to temp buffer
+    _mm512_store_si512((__m512i*)temp[0], h_vecs[0]);
+    _mm512_store_si512((__m512i*)temp[1], h_vecs[1]);
+    _mm512_store_si512((__m512i*)temp[2], h_vecs[2]);
+    _mm512_store_si512((__m512i*)temp[3], h_vecs[3]);
+    _mm512_store_si512((__m512i*)temp[4], h_vecs[4]);
+    _mm512_store_si512((__m512i*)temp[5], h_vecs[5]);
+    _mm512_store_si512((__m512i*)temp[6], h_vecs[6]);
+    _mm512_store_si512((__m512i*)temp[7], h_vecs[7]);
+
+    // Untranspose: for chunk c, CV = [temp[0][c], temp[1][c], ..., temp[7][c]]
+    for (int c = 0; c < 16; c++) {
+        word32 *cv_out = (word32*)(out + c * 32);
+        cv_out[0] = temp[0][c];
+        cv_out[1] = temp[1][c];
+        cv_out[2] = temp[2][c];
+        cv_out[3] = temp[3][c];
+        cv_out[4] = temp[4][c];
+        cv_out[5] = temp[5][c];
+        cv_out[6] = temp[6][c];
+        cv_out[7] = temp[7][c];
+    }
+}
+
+// Hash 16 complete 1KB chunks in parallel using AVX512
+void BLAKE3_Hash16_AVX512(const byte *const *inputs, const word32 key[8],
+                          word64 counter, byte flags, byte *out)
+{
+    __m512i h_vecs[8];
+    __m512i counter_low_vec, counter_high_vec;
+
+    // Initialize state vectors (transposed across 16 chunks)
+    for (size_t i = 0; i < 8; i++) {
+        h_vecs[i] = set1_512(key[i]);
+    }
+
+    // Counter values for each chunk
+    counter_low_vec = set16(
+        (word32)counter, (word32)(counter + 1),
+        (word32)(counter + 2), (word32)(counter + 3),
+        (word32)(counter + 4), (word32)(counter + 5),
+        (word32)(counter + 6), (word32)(counter + 7),
+        (word32)(counter + 8), (word32)(counter + 9),
+        (word32)(counter + 10), (word32)(counter + 11),
+        (word32)(counter + 12), (word32)(counter + 13),
+        (word32)(counter + 14), (word32)(counter + 15));
+
+    counter_high_vec = set16(
+        (word32)(counter >> 32), (word32)((counter + 1) >> 32),
+        (word32)((counter + 2) >> 32), (word32)((counter + 3) >> 32),
+        (word32)((counter + 4) >> 32), (word32)((counter + 5) >> 32),
+        (word32)((counter + 6) >> 32), (word32)((counter + 7) >> 32),
+        (word32)((counter + 8) >> 32), (word32)((counter + 9) >> 32),
+        (word32)((counter + 10) >> 32), (word32)((counter + 11) >> 32),
+        (word32)((counter + 12) >> 32), (word32)((counter + 13) >> 32),
+        (word32)((counter + 14) >> 32), (word32)((counter + 15) >> 32));
+
+    // Process 16 blocks per chunk
+    for (size_t block = 0; block < 16; block++) {
+        __m512i m_vecs[16];
+        transpose_msg_vecs16(inputs, block * BLAKE3_BLOCK_LEN, m_vecs);
+
+        // Determine block flags
+        byte block_flags = flags;
+        if (block == 0) {
+            block_flags |= BLAKE3_CHUNK_START;
+        }
+        if (block == 15) {
+            block_flags |= BLAKE3_CHUNK_END;
+        }
+
+        // Set up state
+        __m512i v[16];
+        v[0] = h_vecs[0];
+        v[1] = h_vecs[1];
+        v[2] = h_vecs[2];
+        v[3] = h_vecs[3];
+        v[4] = h_vecs[4];
+        v[5] = h_vecs[5];
+        v[6] = h_vecs[6];
+        v[7] = h_vecs[7];
+        v[8] = set1_512(BLAKE3_IV[0]);
+        v[9] = set1_512(BLAKE3_IV[1]);
+        v[10] = set1_512(BLAKE3_IV[2]);
+        v[11] = set1_512(BLAKE3_IV[3]);
+        v[12] = counter_low_vec;
+        v[13] = counter_high_vec;
+        v[14] = set1_512(BLAKE3_BLOCK_LEN);
+        v[15] = set1_512(block_flags);
+
+        // 7 rounds
+        round_fn16(v, m_vecs, 0);
+        round_fn16(v, m_vecs, 1);
+        round_fn16(v, m_vecs, 2);
+        round_fn16(v, m_vecs, 3);
+        round_fn16(v, m_vecs, 4);
+        round_fn16(v, m_vecs, 5);
+        round_fn16(v, m_vecs, 6);
+
+        // Update chaining values: h = v[:8] ^ v[8:]
+        h_vecs[0] = xorv512(v[0], v[8]);
+        h_vecs[1] = xorv512(v[1], v[9]);
+        h_vecs[2] = xorv512(v[2], v[10]);
+        h_vecs[3] = xorv512(v[3], v[11]);
+        h_vecs[4] = xorv512(v[4], v[12]);
+        h_vecs[5] = xorv512(v[5], v[13]);
+        h_vecs[6] = xorv512(v[6], v[14]);
+        h_vecs[7] = xorv512(v[7], v[15]);
+    }
+
+    // Transpose back and store outputs
+    transpose_vecs16_out(h_vecs, out);
+}
+
+// Forward declaration of AVX2 fallback
+extern void BLAKE3_Hash8_AVX2(const byte *const *inputs, const word32 key[8],
+                              word64 counter, byte flags, byte *out);
+extern void BLAKE3_Hash4_SSE41(const byte *const *inputs, const word32 key[8],
+                               word64 counter, byte flags, byte *out);
+extern void BLAKE3_Compress_SSE41(word32 cv[8], const byte block[64],
+                                  byte block_len, word64 counter, byte flags);
+
+// Hash multiple chunks using 16-way parallel AVX512 processing
+size_t BLAKE3_HashMany_AVX512(const byte *input, size_t input_len,
+                              const word32 key[8], word64 counter,
+                              byte flags, byte *out)
+{
+    size_t chunks_processed = 0;
+    const size_t num_chunks = input_len / BLAKE3_CHUNK_LEN;
+
+    // Process 16 chunks at a time using AVX512
+    while (chunks_processed + 16 <= num_chunks) {
+        const byte *inputs[16] = {
+            input + chunks_processed * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 1) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 2) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 3) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 4) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 5) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 6) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 7) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 8) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 9) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 10) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 11) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 12) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 13) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 14) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 15) * BLAKE3_CHUNK_LEN
+        };
+
+        BLAKE3_Hash16_AVX512(inputs, key, counter + chunks_processed, flags,
+                             out + chunks_processed * 32);
+        chunks_processed += 16;
+    }
+
+#if CRYPTOPP_AVX2_AVAILABLE
+    // Process remaining 8 chunks with AVX2
+    while (chunks_processed + 8 <= num_chunks) {
+        const byte *inputs[8] = {
+            input + chunks_processed * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 1) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 2) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 3) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 4) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 5) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 6) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 7) * BLAKE3_CHUNK_LEN
+        };
+
+        BLAKE3_Hash8_AVX2(inputs, key, counter + chunks_processed, flags,
+                          out + chunks_processed * 32);
+        chunks_processed += 8;
+    }
+#endif
+
+#if CRYPTOPP_SSE41_AVAILABLE
+    // Process remaining 4 chunks with SSE4.1
+    while (chunks_processed + 4 <= num_chunks) {
+        const byte *inputs[4] = {
+            input + chunks_processed * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 1) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 2) * BLAKE3_CHUNK_LEN,
+            input + (chunks_processed + 3) * BLAKE3_CHUNK_LEN
+        };
+
+        BLAKE3_Hash4_SSE41(inputs, key, counter + chunks_processed, flags,
+                           out + chunks_processed * 32);
+        chunks_processed += 4;
+    }
+
+    // Process remaining chunks one at a time
+    while (chunks_processed < num_chunks) {
+        const byte *chunk_input = input + chunks_processed * BLAKE3_CHUNK_LEN;
+        word32 cv[8];
+        std::memcpy(cv, key, 32);
+
+        for (size_t block = 0; block < 16; block++) {
+            byte block_flags = flags;
+            if (block == 0) block_flags |= BLAKE3_CHUNK_START;
+            if (block == 15) block_flags |= BLAKE3_CHUNK_END;
+
+            BLAKE3_Compress_SSE41(cv, chunk_input + block * BLAKE3_BLOCK_LEN,
+                                  BLAKE3_BLOCK_LEN, counter + chunks_processed,
+                                  block_flags);
+        }
+
+        std::memcpy(out + chunks_processed * 32, cv, 32);
+        chunks_processed++;
+    }
+#endif
+
+    return chunks_processed;
+}
+
+#endif  // CRYPTOPP_AVX512F_AVAILABLE && CRYPTOPP_AVX512VL_AVAILABLE
+
+NAMESPACE_END

--- a/src/test/bench1.cpp
+++ b/src/test/bench1.cpp
@@ -189,9 +189,9 @@ void BenchMark(const char *name, StreamTransformation &cipher, double timeTotal)
 
 void BenchMark(const char *name, HashTransformation &ht, double timeTotal)
 {
-	// Use 16KB buffer to enable BLAKE3's parallel chunk processing
-	// (4KB minimum for SSE4.1 4-way, 8KB for AVX2 8-way)
-	const int BUF_SIZE=16384U;
+	// Use 64KB buffer to enable BLAKE3's parallel chunk processing
+	// (4KB for SSE4.1 4-way, 8KB for AVX2 8-way, 16KB for AVX512 16-way)
+	const int BUF_SIZE=65536U;
 	AlignedSecByteBlock buf(BUF_SIZE);
 	Test::GlobalRNG().GenerateBlock(buf, BUF_SIZE);
 	buf.SetMark(16);

--- a/src/test/bench2.cpp
+++ b/src/test/bench2.cpp
@@ -134,6 +134,7 @@ void BenchmarkSharedKeyedAlgorithms(double t, double hertz)
 		BenchMarkByName<MessageAuthenticationCode>("Poly1305TLS");
 		BenchMarkByName<MessageAuthenticationCode>("BLAKE2s");
 		BenchMarkByName<MessageAuthenticationCode>("BLAKE2b");
+		BenchMarkByName<MessageAuthenticationCode>("BLAKE3");
 		BenchMarkByName<MessageAuthenticationCode>("SipHash-2-4");
 		BenchMarkByName<MessageAuthenticationCode>("SipHash-4-8");
 	}

--- a/src/test/regtest2.cpp
+++ b/src/test/regtest2.cpp
@@ -22,6 +22,7 @@
 #include <cryptopp/sha.h>
 #include <cryptopp/sha3.h>
 #include <cryptopp/blake2.h>
+#include <cryptopp/blake3.h>
 #include <cryptopp/ripemd.h>
 #include <cryptopp/chacha.h>
 #include <cryptopp/poly1305.h>
@@ -77,6 +78,7 @@ void RegisterFactories2()
 	RegisterDefaultFactoryFor<MessageAuthenticationCode, CMAC<DES_EDE3> >();
 	RegisterDefaultFactoryFor<MessageAuthenticationCode, BLAKE2s>();
 	RegisterDefaultFactoryFor<MessageAuthenticationCode, BLAKE2b>();
+	RegisterDefaultFactoryFor<MessageAuthenticationCode, BLAKE3>();
 	RegisterDefaultFactoryFor<MessageAuthenticationCode, SipHash<2,4> >();
 	RegisterDefaultFactoryFor<MessageAuthenticationCode, SipHash<4,8> >();
 }

--- a/src/test/validat3.cpp
+++ b/src/test/validat3.cpp
@@ -391,6 +391,8 @@ bool TestSettings()
 	bool hasSSE42 = HasSSE42();
 	bool hasAVX = HasAVX();
 	bool hasAVX2 = HasAVX2();
+	bool hasAVX512F = HasAVX512F();
+	bool hasAVX512VL = HasAVX512VL();
 	bool hasAESNI = HasAESNI();
 	bool hasCLMUL = HasCLMUL();
 	bool hasRDRAND = HasRDRAND();
@@ -400,7 +402,7 @@ bool TestSettings()
 
 	std::cout << "hasSSE2 == " << hasSSE2 << ", hasSSSE3 == " << hasSSSE3;
 	std::cout << ", hasSSE4.1 == " << hasSSE41 << ", hasSSE4.2 == " << hasSSE42;
-	std::cout << ", hasAVX == " << hasAVX << ", hasAVX2 == " << hasAVX2;
+	std::cout << ", hasAVX == " << hasAVX << ", hasAVX2 == " << hasAVX2 << ", hasAVX512F == " << hasAVX512F << ", hasAVX512VL == " << hasAVX512VL;
 	std::cout << ", hasAESNI == " << hasAESNI << ", hasCLMUL == " << hasCLMUL;
 	std::cout << ", hasRDRAND == " << hasRDRAND << ", hasRDSEED == " << hasRDSEED;
 	std::cout << ", hasSHA == " << hasSHA << ", isP4 == " << isP4;


### PR DESCRIPTION
## Summary
  - Implement BLAKE3_HashMany_AVX512 for 16-way parallel processing
  - Add AVX512F and AVX512VL detection and runtime dispatch
  - Restrict AVX512 to x64 builds only (not available on 32-bit)
  - Add MSVC project file entries with /arch:AVX512 flag
  - Add CMake and GNUmakefile support for AVX512 compilation
  - Add AVX512 test job to branch CI workflow