### PR TITLE
Reject non-canonical Ed25519 public keys (y >= p)

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -214,7 +214,7 @@ The build system automatically detects CPU capabilities and enables appropriate 
 - CLMUL (carryless multiplication for GCM)
 - SHA-NI (hardware SHA acceleration)
 
-**BLAKE3 Parallel Hashing**: BLAKE3 uses SSE4.1 (4-way), AVX2 (8-way), and AVX-512 (16-way) parallel chunk processing for high performance (~2500 MiB/s with AVX2, ~4000+ MiB/s with AVX-512).
+**BLAKE3 Parallel Hashing**: BLAKE3 uses SSE4.1 (4-way), AVX2 (8-way), and AVX-512 (16-way) parallel chunk processing for high performance (~2500 MiB/s with AVX2, over 4000 MiB/s with AVX-512).
 
 ### ARM
 - NEON

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Crypto++
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.3
+PROJECT_NUMBER         = 2026.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/FORK.md
+++ b/FORK.md
@@ -1,6 +1,6 @@
 # FORK.md - Relationship to Upstream Crypto++
 
-**cryptopp-modern** is a friendly fork of [Crypto++](https://github.com/weidai11/cryptopp), maintained separately to add modern algorithms and improve the library structure.
+**cryptopp-modern** is a maintained fork of [Crypto++](https://github.com/weidai11/cryptopp), separated to add modern algorithms and improve the library structure.
 
 ---
 
@@ -26,13 +26,30 @@
 
 ### cryptopp-modern Releases
 
+**2026.4.0** (April 2026) - Security Fix
+- Fixed Crypto++ Issue #1348: Ed25519 verification accepts non-canonical public keys
+- Validate() and Donna verifiers now reject y >= p per RFC 8032
+
+**2026.3.0** (March 2026) - Post-Quantum Cryptography Release
+- Added ML-KEM (FIPS 203) key encapsulation (512/768/1024)
+- Added ML-DSA (FIPS 204) digital signatures (44/65/87)
+- Added SLH-DSA (FIPS 205) hash-based signatures (all 12 parameter sets)
+- Added X-Wing hybrid KEM (X25519 + ML-KEM-768, IETF draft)
+- ASN.1/DER key encoding for PQC algorithms (PKCS#8, X.509)
+- Added XAES-256-GCM extended-nonce authenticated encryption
+
+**2026.2.1** (February 2026) - Correctness Fix
+- Fixed Crypto++ Issue #1342: DSA/ECDSA invalid signature (r=0 or s=0) in release builds
+- Probabilistic signatures retry with fresh random k
+- Deterministic signatures (RFC 6979) abort with exception
+
 **2026.2.0** (February 2026) - Security Release
 - Fixed CVE-2024-28285: Hardened hybrid DL decryption against fault injection
 - No-write-on-failure guarantee for ElGamal, ECIES, DLIES decryption
 - Exponent blinding verification to detect faulted computations
 
 **2026.1.0** (January 2026) - Minor Release
-- Added BLAKE3 AVX-512 16-way parallel chunk hashing (~4000+ MiB/s)
+- Added BLAKE3 AVX-512 16-way parallel chunk hashing (over 4000 MiB/s)
 - Added XAES-256-GCM extended-nonce authenticated encryption (C2SP spec)
 - Added AES-CTR-HMAC authenticated encryption (encrypt-then-MAC)
 - Hardened XAES-256-GCM and AES-CTR-HMAC against misuse
@@ -91,7 +108,7 @@
 
 ## Upstream Relationship
 
-This is a friendly fork to:
+This is a maintained fork to:
 - Serve users who need modern algorithms and faster development
 - Provide an alternative for active maintenance
 - Experiment with improvements
@@ -107,11 +124,11 @@ This is a friendly fork to:
 
 ### cryptopp-modern vs. Upstream Crypto++
 
-| Aspect | Crypto++ 8.9.0 | cryptopp-modern 2026.3.0 |
+| Aspect | Crypto++ 8.9.0 | cryptopp-modern 2026.4.0 |
 |--------|----------------|---------------------------|
-| **Last Release** | October 1, 2023 | March 2026 |
-| **Versioning** | Semantic (8.9.0) | Calendar (2026.3.0) |
-| **BLAKE3** | ❌ | ✅ with AVX-512 (~4000+ MiB/s) |
+| **Last Release** | October 1, 2023 | April 2026 |
+| **Versioning** | Semantic (8.9.0) | Calendar (2026.4.0) |
+| **BLAKE3** | ❌ | ✅ with AVX-512 (over 4000 MiB/s) |
 | **Argon2** | ❌ | ✅ RFC 9106 |
 | **XAES-256-GCM** | ❌ | ✅ C2SP spec |
 | **AES-CTR-HMAC** | ❌ | ✅ Encrypt-then-MAC |
@@ -145,6 +162,6 @@ This is a friendly fork to:
 
 ---
 
-**Last Updated:** 2026-02-19
+**Last Updated:** 2026-04-24
 **Fork Point:** Crypto++ 8.9.0 (commit 60f81a77)
-**Current Version:** 2026.3.0
+**Current Version:** 2026.4.0

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -115,8 +115,8 @@ The GNUmakefile provides a straightforward Make-based build, suitable for classi
 
 ```bash
 # Download latest release
-wget https://github.com/cryptopp-modern/cryptopp-modern/releases/download/2026.3.0/cryptopp-modern-2026.3.0.zip
-unzip cryptopp-modern-2026.3.0.zip -d cryptopp-modern
+wget https://github.com/cryptopp-modern/cryptopp-modern/releases/download/2026.4.0/cryptopp-modern-2026.4.0.zip
+unzip cryptopp-modern-2026.4.0.zip -d cryptopp-modern
 cd cryptopp-modern
 
 # Build and install
@@ -129,8 +129,8 @@ sudo ldconfig
 
 ```bash
 # Download and extract
-wget https://github.com/cryptopp-modern/cryptopp-modern/releases/download/2026.3.0/cryptopp-modern-2026.3.0.zip
-unzip cryptopp-modern-2026.3.0.zip -d cryptopp-modern
+wget https://github.com/cryptopp-modern/cryptopp-modern/releases/download/2026.4.0/cryptopp-modern-2026.4.0.zip
+unzip cryptopp-modern-2026.4.0.zip -d cryptopp-modern
 cd cryptopp-modern
 
 # Build and install
@@ -141,7 +141,7 @@ sudo make install PREFIX=/usr/local
 #### Windows (MinGW)
 
 ```bash
-# Download and extract cryptopp-modern-2026.3.0.zip
+# Download and extract cryptopp-modern-2026.4.0.zip
 # Open MinGW terminal in extracted folder
 
 # Build
@@ -157,7 +157,7 @@ mingw32-make.exe -j10 BUILD=release
 
 Visual Studio provides native Windows development with full IDE support, debugging, and IntelliSense.
 
-1. Download and extract cryptopp-modern-2026.3.0.zip
+1. Download and extract cryptopp-modern-2026.4.0.zip
 2. Open `cryptest.sln` in Visual Studio
 3. Build → Build Solution (Ctrl+Shift+B)
 

--- a/GNUMAKEFILE.md
+++ b/GNUMAKEFILE.md
@@ -313,7 +313,7 @@ The GNUmakefile automatically detects and enables CPU features:
 - PCLMUL (CLMUL)
 - SHA-NI
 
-**BLAKE3 Parallel Hashing**: BLAKE3 uses SSE4.1 (4-way), AVX2 (8-way), and AVX-512 (16-way) parallel chunk processing for high performance (~2500 MiB/s with AVX2, ~4000+ MiB/s with AVX-512).
+**BLAKE3 Parallel Hashing**: BLAKE3 uses SSE4.1 (4-way), AVX2 (8-way), and AVX-512 (16-way) parallel chunk processing for high performance (~2500 MiB/s with AVX2, over 4000 MiB/s with AVX-512).
 
 ### ARM
 - NEON

--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,12 @@ The History file contains the items that comprise the release notes. The
 items in the list below used to be in Readme.txt. Readme.txt now contans the
 last several releases.
 
+2026.4.0 - April 2026
+      - security release
+      - fixed Ed25519 accepting non-canonical public keys (Issue #1348)
+        * Validate() and verifier now reject y >= p per RFC 8032
+        * covers both 32-bit and 64-bit Donna paths
+
 2026.3.0 - March 2026
       - major release, recompile of programs required
       - added post-quantum cryptography (PQC) implementations
@@ -42,7 +48,7 @@ last several releases.
       - minor release
       - added BLAKE3 AVX-512 16-way parallel chunk hashing
         * 16-way parallel processing using AVX-512F and AVX-512VL
-        * ~4000+ MiB/s on supported processors
+        * over 4000 MiB/s on supported processors
         * automatic runtime CPU detection with graceful fallback
       - added XAES-256-GCM extended-nonce authenticated encryption
         * 256-bit (32-byte) nonces safe for random generation

--- a/README.md
+++ b/README.md
@@ -2,37 +2,31 @@
 
 **A maintained, modernized fork of Crypto++ with new algorithms and security improvements**
 
-[![Version](https://img.shields.io/badge/version-2026.3.0-blue.svg)](https://github.com/cryptopp-modern/cryptopp-modern/releases)
+[![Version](https://img.shields.io/badge/version-2026.4.0-blue.svg)](https://github.com/cryptopp-modern/cryptopp-modern/releases)
 [![License](https://img.shields.io/badge/license-Boost-green.svg)](LICENSE)
 
 ---
 
 ## Overview
 
-🌐 **Website:** [cryptopp-modern.com](https://cryptopp-modern.com)
+**Website:** [cryptopp-modern.com](https://cryptopp-modern.com)
 
 **cryptopp-modern** is an actively maintained fork of [Crypto++ 8.9.0](https://github.com/weidai11/cryptopp) featuring:
 
-- ✨ **Post-Quantum Cryptography** - ML-KEM (FIPS 203), ML-DSA (FIPS 204), SLH-DSA (FIPS 205), X-Wing hybrid KEM
-- ✨ **BLAKE3** - Modern, fast cryptographic hash function
-- ✨ **Argon2** - RFC 9106 password hashing (Argon2d, Argon2i, Argon2id)
-- 🔒 **Security Patches** - Marvin attack fix (CVE-2023-50979), fault injection fix (CVE-2024-28285), ESIGN improvements
-- 📅 **Calendar Versioning** - Clear release dates (YEAR.MONTH.INCREMENT format)
-- 🔄 **Active Maintenance** - Regular updates and improvements
-- ✅ **Drop-in Compatible** - Uses same `CryptoPP` namespace
+- **Post-Quantum Cryptography** - ML-KEM (FIPS 203), ML-DSA (FIPS 204), SLH-DSA (FIPS 205), X-Wing hybrid KEM
+- **BLAKE3** - Modern, fast cryptographic hash function
+- **Argon2** - RFC 9106 password hashing (Argon2d, Argon2i, Argon2id)
+- **Security Patches** - Marvin attack fix (CVE-2023-50979), fault injection fix (CVE-2024-28285), ESIGN improvements
+- **Calendar Versioning** - Clear release dates (YEAR.MONTH.INCREMENT format)
+- **Active Maintenance** - Regular updates and improvements
+- **Drop-in Compatible** - Uses same `CryptoPP` namespace
 
 ---
 
 
-## What's New in 2026.3.0
+## What's New in 2026.4.0
 
-- ✨ **ML-KEM** - FIPS 203 key encapsulation (ML-KEM-512, ML-KEM-768, ML-KEM-1024)
-- ✨ **ML-DSA** - FIPS 204 digital signatures (ML-DSA-44, ML-DSA-65, ML-DSA-87)
-- ✨ **SLH-DSA** - FIPS 205 stateless hash-based signatures (all 12 parameter sets)
-- ✨ **X-Wing** - Hybrid KEM combining X25519 and ML-KEM-768
-- ✨ **XAES-256-GCM** - Extended-nonce AES-256-GCM (C2SP specification)
-- 🔧 **GNUmakefile BUILD flag** - Support for release, debug, and relwithdebinfo modes
-- 🔒 **Security hardening** - Constant-time operations, stack zeroization, input validation
+- **Ed25519 canonicality fix** - Rejects non-canonical public keys (y >= p) per RFC 8032 (Issue #1348)
 
 ---
 
@@ -127,12 +121,12 @@ See [Readme.txt](Readme.txt) for complete algorithm list.
 
 **Good news:** Most code works unchanged!
 
-### Compatible ✓
+### Compatible
 - All existing algorithms and APIs
 - Same `CryptoPP` namespace
 - Version checks: `#if CRYPTOPP_VERSION >= N`
 
-### Changed ⚠️
+### Changed
 - Version encoding: Now `YEAR*10000 + MONTH*100 + INCREMENT`
 - Version parsing: Use `/10000` for year, `(n/100)%100` for month
 
@@ -152,13 +146,13 @@ const int month = (CRYPTOPP_VERSION / 100) % 100;  // Gets 11
 
 Contributions are welcome! Areas where you can help:
 
-- 🐛 Bug reports and fixes
-- ✨ New algorithm implementations
-- 📚 Documentation improvements
-- 🧪 Tests and test vectors
-- 🔧 Build system enhancements
+- Bug reports and fixes
+- New algorithm implementations
+- Documentation improvements
+- Tests and test vectors
+- Build system enhancements
 
-If you're migrating from Crypto++ 8.9.0 and encounter any issues, please open an issue – migration feedback is especially valuable.
+If you're migrating from Crypto++ 8.9.0 and encounter any issues, please open an issue. Migration feedback is especially valuable.
 
 Please:
 1. Fork the repository

--- a/RELEASE-2026.4.0.md
+++ b/RELEASE-2026.4.0.md
@@ -1,0 +1,54 @@
+# cryptopp-modern 2026.4.0 Release Notes
+
+**Release Date:** April 2026
+**Release Type:** Minor Release (Security Fix)
+
+---
+
+## Overview
+
+cryptopp-modern 2026.4.0 fixes **Crypto++ Issue #1348**, a canonicality
+bug in Ed25519 verification where public keys with y >= p were accepted.
+
+---
+
+## Security Fix
+
+### Issue #1348: Ed25519 Accepts Non-Canonical Public Keys
+
+**Component:** Ed25519 signature verification and public-key validation
+
+**Issue:** `ed25519PublicKey::Validate()` returned true unconditionally,
+and the Donna verifiers unpacked public keys without checking
+canonicality. Per RFC 8032, the encoded y coordinate must be less than
+p = 2^255 - 19. Without this check, y = p + 1 and similar aliases were
+accepted as the identity point. Multiple byte encodings mapped to one
+group element.
+
+**Severity:** Low. Conformance issue, no forgery risk. Matters where
+raw pubkey bytes are authoritative: pinning, allowlists, dedup, audit
+trails, interop with stricter verifiers.
+
+**Affected Versions:** All versions prior to 2026.4.0
+
+### Changes
+
+- `src/pubkey/xed25519.cpp`: `IsCanonicalY` helper; `Validate()` now
+  rejects y >= p
+- `src/pubkey/donna_32.cpp` / `donna_64.cpp`: `ed25519_pubkey_is_canonical`
+  helper; verify path rejects y >= p before unpacking
+- `src/test/validat9.cpp`: regression test covering y = 1, y = p - 1
+  (canonical) and y = p, y = p + 1, y = 2^255 - 1 (non-canonical)
+  against the RFC 8032 witness signature
+
+### References
+
+- [Upstream Issue #1348](https://github.com/weidai11/cryptopp/issues/1348)
+
+---
+
+## Upgrade Notes
+
+`ed25519PublicKey::Validate()` is stricter. Code that relied on it
+always returning true will see false for non-canonical keys. Keys
+produced by compliant implementations are unaffected.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # cryptopp-modern Development Roadmap
 
-**Current Version:** 2026.3.0
+**Current Version:** 2026.4.0
 
 ---
 
@@ -114,7 +114,7 @@
   - Validation tests and test vectors on all platforms
 
 ### Planned (Future)
-- 📊 **Code Quality Enhancements**
+- **Code Quality Enhancements**
   - Memory Sanitizer (MSan)
   - Static analysis (clang-tidy, cppcheck)
   - Code coverage reporting
@@ -153,12 +153,12 @@
 
 We welcome contributions in these areas:
 
-- 🐛 **Bug Reports** - Find and report issues
-- ✨ **New Algorithms** - Implement modern crypto algorithms
-- 📚 **Documentation** - Improve docs and examples
-- 🧪 **Testing** - Add tests and test vectors
-- 🔧 **Build System** - Improve CMake and cross-platform support
-- 📦 **Packaging** - Help with package manager integration
+- **Bug Reports** - Find and report issues
+- **New Algorithms** - Implement modern crypto algorithms
+- **Documentation** - Improve docs and examples
+- **Testing** - Add tests and test vectors
+- **Build System** - Improve CMake and cross-platform support
+- **Packaging** - Help with package manager integration
 
 See [FORK.md](FORK.md) for project details and direction.
 
@@ -166,56 +166,60 @@ See [FORK.md](FORK.md) for project details and direction.
 
 ## Version History
 
+### 2026.4.0 (April 2026) - Security Fix
+- **Ed25519 Canonicality** - Fixed accepting non-canonical public keys (Issue #1348)
+- Regression test covering canonical and non-canonical y vectors
+
 ### 2026.3.0 (March 2026) - Post-Quantum Cryptography Release
-- 🔐 **ML-KEM (FIPS 203)** - Module-Lattice Key Encapsulation (512/768/1024)
-- 🔐 **ML-DSA (FIPS 204)** - Module-Lattice Digital Signatures (44/65/87)
-- 🔐 **SLH-DSA (FIPS 205)** - Stateless Hash-Based Signatures (all 12 parameter sets)
-- 🔐 **X-Wing** - Hybrid KEM combining X25519 + ML-KEM-768 (IETF draft)
-- 🔧 ASN.1/DER key encoding for PQC algorithms (PKCS#8, X.509)
-- 🧪 NIST ACVP test vectors for all PQC algorithms
-- 🔧 Updated build systems (GNUmakefile, nmake, Visual Studio)
+- **ML-KEM (FIPS 203)** - Module-Lattice Key Encapsulation (512/768/1024)
+- **ML-DSA (FIPS 204)** - Module-Lattice Digital Signatures (44/65/87)
+- **SLH-DSA (FIPS 205)** - Stateless Hash-Based Signatures (all 12 parameter sets)
+- **X-Wing** - Hybrid KEM combining X25519 + ML-KEM-768 (IETF draft)
+- ASN.1/DER key encoding for PQC algorithms (PKCS#8, X.509)
+- NIST ACVP test vectors for all PQC algorithms
+- Updated build systems (GNUmakefile, nmake, Visual Studio)
 
 ### 2026.2.1 (February 2026) - Correctness Fix
-- 🔧 **DSA/ECDSA Fix** - Fixed invalid signature (r=0 or s=0) in release builds (Issue #1342)
+- **DSA/ECDSA Fix** - Fixed invalid signature (r=0 or s=0) in release builds (Issue #1342)
 
 ### 2026.2.0 (February 2026) - Security Release
-- 🔒 **CVE-2024-28285 Fix** - Hardened hybrid DL decryption (ElGamal, ECIES, DLIES) against fault injection
-- 🛡️ **No-Write-on-Failure** - Plaintext buffer untouched unless decryption succeeds
-- ✅ **Blinded Verification** - Detects faulted key-agreement computations before releasing plaintext
+- **CVE-2024-28285 Fix** - Hardened hybrid DL decryption (ElGamal, ECIES, DLIES) against fault injection
+- **No-Write-on-Failure** - Plaintext buffer untouched unless decryption succeeds
+- **Blinded Verification** - Detects faulted key-agreement computations before releasing plaintext
 
 ### 2026.1.0 (January 2026) - New Algorithms Release
-- ⚡ **BLAKE3 AVX-512** - 16-way parallel chunk hashing
-  - ~4000+ MiB/s on supported processors
+- **BLAKE3 AVX-512** - 16-way parallel chunk hashing
+  - over 4000 MiB/s on supported processors
   - Automatic runtime CPU detection with graceful fallback
-- ✨ **XAES-256-GCM** - Extended-nonce AES-GCM (C2SP specification)
+- **XAES-256-GCM** - Extended-nonce AES-GCM (C2SP specification)
   - 256-bit (32-byte) nonces safe for random generation
   - Solves nonce management problem for AES-GCM users
-- ✨ **AES-CTR-HMAC** - Encrypt-then-MAC authenticated encryption
+- **AES-CTR-HMAC** - Encrypt-then-MAC authenticated encryption
   - Template-based: works with any block cipher and hash function
   - HKDF key derivation for encryption and MAC keys
-- 🔒 Hardened XAES-256-GCM and AES-CTR-HMAC against misuse
-- 🔧 Improved exception safety and portability
-- 🔧 Dropped non-standard stdext namespace usage
+- Hardened XAES-256-GCM and AES-CTR-HMAC against misuse
+- Improved exception safety and portability
+- Dropped non-standard stdext namespace usage
 
 ### 2025.12.0 (December 2025) - Organization & CMake Release
-- 📁 Complete project reorganization (Phase 2)
-- 🏗️ Organized 204 source files into categorized `src/` directories
-- 📦 Maintained backward compatibility with flat include structure
-- 🔧 Modern CMake build system with presets and `find_package()` support (Phase 3)
-- ⚡ BLAKE3 SIMD parallel chunk processing
+- Complete project reorganization (Phase 2)
+- Organized 204 source files into categorized `src/` directories
+- Maintained backward compatibility with flat include structure
+- Modern CMake build system with presets and `find_package()` support (Phase 3)
+- BLAKE3 SIMD parallel chunk processing
   - SSE4.1 4-way and AVX2 8-way parallel hashing (~2500 MiB/s)
   - ARM NEON support with graceful fallback
-- ✅ Unified CI/CD workflow with 50+ build configurations (Phase 5)
-- 🔧 Updated build systems (GNUmakefile, MSVC, nmake, CMake)
-- 📚 Comprehensive documentation (CMAKE.md, GNUMAKEFILE.md, GETTING_STARTED.md)
-- 🧪 Comprehensive testing across all platforms
+- Unified CI/CD workflow with 50+ build configurations (Phase 5)
+- Updated build systems (GNUmakefile, MSVC, nmake, CMake)
+- Comprehensive documentation (CMAKE.md, GNUMAKEFILE.md, GETTING_STARTED.md)
+- Comprehensive testing across all platforms
 
 ### 2025.11.0 (November 2025) - Foundation Release
-- 🎉 First release with calendar versioning
-- ✨ Added BLAKE3 cryptographic hash
-- ✨ Added Argon2 password hashing (d/i/id variants)
-- 🔒 Fixed Marvin attack (CVE-2023-50979)
-- 🔒 Improved ESIGN static analyzer compatibility
+- First release with calendar versioning
+- Added BLAKE3 cryptographic hash
+- Added Argon2 password hashing (d/i/id variants)
+- Fixed Marvin attack (CVE-2023-50979)
+- Improved ESIGN static analyzer compatibility
 
 ---
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,5 +1,5 @@
 cryptopp-modern: Maintained Fork of the Crypto++ Library
-Version 2026.3.0 - March 2026
+Version 2026.4.0 - April 2026
 
 cryptopp-modern is an actively maintained fork of the Crypto++ library,
 a free C++ class library of cryptographic schemes. The library contains
@@ -307,6 +307,12 @@ documentation is one of the highest returns on investment.
 The items in this section comprise the most recent history. Please see History.txt
 for the record back to Crypto++ 1.0.
 
+2026.4.0 - April 2026
+      - security release
+      - fixed Ed25519 accepting non-canonical public keys (Issue #1348)
+        * Validate() and verifier now reject y >= p per RFC 8032
+        * covers both 32-bit and 64-bit Donna paths
+
 2026.3.0 - March 2026
       - major release, recompile of programs required
       - added post-quantum cryptography (PQC) implementations
@@ -337,7 +343,7 @@ for the record back to Crypto++ 1.0.
 2026.1.0 - January 2026
       - minor release
       - added BLAKE3 AVX-512 16-way parallel chunk hashing
-        * ~4000+ MiB/s on supported processors
+        * over 4000 MiB/s on supported processors
         * automatic runtime CPU detection with fallback
       - added XAES-256-GCM extended-nonce authenticated encryption
         * 256-bit (32-byte) nonces safe for random generation

--- a/Security.md
+++ b/Security.md
@@ -2,15 +2,10 @@
 
 ## Supported Versions
 
-We support modern versions of cryptopp-modern. Modern versions include the main branch and the latest release.
+Currently supported:
+- 2026.4.0 (current release)
 
-Currently supported versions:
-- 2026.2.1
-- 2026.2.0
-- 2026.1.0
-- 2025.12.0
-
-We also incorporate critical security fixes from upstream Crypto++ and monitor for security issues in the cryptographic algorithms we implement.
+Older releases are not actively supported. Users on earlier versions should upgrade to receive security fixes. We incorporate critical security fixes from upstream Crypto++ and monitor for security issues in the cryptographic algorithms we implement.
 
 ## Reporting a Vulnerability
 
@@ -27,6 +22,20 @@ If we receive a report of a security related bug then we will:
 All information will be made public after a fix is available. We do not withhold information from users because stakeholders need accurate information to assess risk and place controls to remediate the risk.
 
 ## Security Advisories
+
+### Ed25519 non-canonical public key acceptance (fixed in 2026.4.0)
+
+`ed25519PublicKey::Validate()` returned true unconditionally, and the Donna verifiers unpacked public keys without checking canonicality. Per RFC 8032, the encoded y coordinate must be less than p = 2^255 - 19. Without this check, y = p + 1 and similar aliases were accepted as the identity point.
+
+**Severity:** Low. Conformance issue, no forgery risk. Matters where raw pubkey bytes are authoritative: pinning, allowlists, dedup, audit trails, interop with stricter verifiers.
+
+**Affected versions:** All versions prior to 2026.4.0.
+
+**Fix:** `Validate()` and both Donna verifiers (32-bit and 64-bit) now reject y >= p. Regression test in `ValidateEd25519` covers canonical (y = 1, p-1) and non-canonical (p, p+1, 2^255-1) vectors.
+
+See [upstream issue #1348](https://github.com/weidai11/cryptopp/issues/1348).
+
+---
 
 ### Crypto++ Issue #1342: DSA/ECDSA Invalid Signature (Fixed in 2026.2.1)
 

--- a/src/pubkey/donna_32.cpp
+++ b/src/pubkey/donna_32.cpp
@@ -510,6 +510,15 @@ using CryptoPP::SHA512;
 // Bring in all the symbols from the 32-bit header
 using namespace CryptoPP::Donna::Arch32;
 
+/* Reject y >= p (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_pubkey_is_canonical(const byte pk[32]) {
+    if ((pk[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (pk[i] != 0xff) return true;
+    return pk[0] < 0xed;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -2038,7 +2047,8 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -2066,7 +2076,8 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/src/pubkey/donna_64.cpp
+++ b/src/pubkey/donna_64.cpp
@@ -438,6 +438,15 @@ using CryptoPP::SHA512;
 // Bring in all the symbols from the 64-bit header
 using namespace CryptoPP::Donna::Arch64;
 
+/* Reject y >= p (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_pubkey_is_canonical(const byte pk[32]) {
+    if ((pk[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (pk[i] != 0xff) return true;
+    return pk[0] < 0xed;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -1751,7 +1760,8 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -1779,7 +1789,8 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/src/pubkey/xed25519.cpp
+++ b/src/pubkey/xed25519.cpp
@@ -65,6 +65,15 @@ bool HasSmallOrder(const byte y[32])
     return (bool)((k >> 8) & 1);
 }
 
+// Reject y >= p (RFC 8032 canonical encoding check).
+bool IsCanonicalY(const byte y[32])
+{
+    if ((y[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (y[i] != 0xff) return true;
+    return y[0] < 0xed;
+}
+
 ANONYMOUS_NAMESPACE_END
 
 NAMESPACE_BEGIN(CryptoPP)
@@ -835,7 +844,7 @@ const Integer& ed25519PublicKey::GetPublicElement() const
 bool ed25519PublicKey::Validate(RandomNumberGenerator &rng, unsigned int level) const
 {
     CRYPTOPP_UNUSED(rng); CRYPTOPP_UNUSED(level);
-    return true;
+    return IsCanonicalY(m_pk);
 }
 
 ////////////////////////

--- a/src/test/validat9.cpp
+++ b/src/test/validat9.cpp
@@ -728,6 +728,63 @@ bool ValidateEd25519()
 	std::cout << (fail ? "FAILED    " : "passed    ");
 	std::cout << "verification check against test vector\n";
 
+	// Non-canonical public-key rejection (RFC 8032).
+	try {
+		// canonical y
+		const byte pk_id[32] = { 0x01 };
+		const byte pk_pminus1[32] = {
+			0xec,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		// non-canonical y: p, p+1, 2^255-1
+		const byte pk_p[32] = {
+			0xed,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		const byte pk_pplus1[32] = {
+			0xee,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		const byte pk_top[32] = {
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+
+		ed25519PublicKey k_id; k_id.SetPublicElement(pk_id);
+		ed25519PublicKey k_pminus1; k_pminus1.SetPublicElement(pk_pminus1);
+		ed25519PublicKey k_p; k_p.SetPublicElement(pk_p);
+		ed25519PublicKey k_pplus1; k_pplus1.SetPublicElement(pk_pplus1);
+		ed25519PublicKey k_top; k_top.SetPublicElement(pk_top);
+
+		const bool v_id = k_id.Validate(NullRNG(), 3);
+		const bool v_pminus1 = k_pminus1.Validate(NullRNG(), 3);
+		const bool v_p = k_p.Validate(NullRNG(), 3);
+		const bool v_pplus1 = k_pplus1.Validate(NullRNG(), 3);
+		const bool v_top = k_top.Validate(NullRNG(), 3);
+
+		// R = identity, S = 0 verifies against the identity key and any of its aliases.
+		byte sig[64] = { 0 };
+		sig[0] = 0x01;
+		const byte msg[] = { 't','e','s','t' };
+
+		ed25519Verifier ver_id(pk_id);
+		ed25519Verifier ver_p(pk_p);
+		ed25519Verifier ver_pplus1(pk_pplus1);
+		ed25519Verifier ver_top(pk_top);
+
+		const bool s_id = ver_id.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_p = ver_p.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_pplus1 = ver_pplus1.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_top = ver_top.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+
+		fail = !(v_id && v_pminus1 && !v_p && !v_pplus1 && !v_top &&
+		         s_id && !s_p && !s_pplus1 && !s_top);
+	}
+	catch (const Exception&) {
+		fail = true;
+	}
+
+	pass = pass && !fail;
+
+	std::cout << (fail ? "FAILED    " : "passed    ");
+	std::cout << "non-canonical public-key rejection\n";
+
 	return pass;
 }
 


### PR DESCRIPTION
## Summary

Ed25519 Validate() returned true unconditionally, and the Donna verifier
unpacked pubkeys without checking canonicality. y >= p = 2^255 - 19 was
accepted, so y = p + 1 aliased to the identity point.

Matters anywhere raw pubkey bytes are authoritative: pinning, dedup, audit trails.

## Changes

- Canonical-y check in xed25519.cpp and donna_{32,64}.cpp
- Validate() and verify path both reject y >= p
- Regression test covering y = 1, p-1, p, p+1, 2^255-1

## Test plan

- [x] cryptest.exe v passes locally
- [x] CI matrix

Upstream: weidai11/cryptopp#1348