### PR TITLE
Sync small fixes from upstream cryptopp

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -157,7 +157,7 @@ To use the Crypto++ DLL in your application, #include "dll.h" before including
 any other Crypto++ header files, and place the DLL in the same directory as
 your .exe file. dll.h includes the line #pragma comment(lib, "cryptopp")
 so you don't have to explicitly list the import library in your project
-settings. To use a static library form of Crypto++, make the "cryptlib"
+settings. Otherwise, to use a static library form of Crypto++, make the "cryptlib"
 project a dependency of your application project, or specify it as
 an additional library to link with in your project settings.
 In either case you should check the compiler options to

--- a/TestScripts/setenv-ios.sh
+++ b/TestScripts/setenv-ios.sh
@@ -91,6 +91,7 @@ unset IOS_CFLAGS
 unset IOS_CXXFLAGS
 unset IOS_LDFLAGS
 unset IOS_SYSROOT
+unset CRC
 
 #########################################
 #####    Small Fixups, if needed    #####
@@ -133,6 +134,7 @@ fi
 
 if [[ "${IOS_CPU}" == "aarch64" || "${IOS_CPU}" == "arm64"* || "${IOS_CPU}" == "armv8"* ]] ; then
     IOS_CPU=arm64
+    CRC="-mcrc"
 fi
 
 echo "Configuring for ${IOS_SDK} (${IOS_CPU})"
@@ -282,7 +284,7 @@ if [ -z "${XCODE_SDK}" ]; then
 fi
 
 IOS_CFLAGS="-arch ${IOS_CPU} ${MIN_VER} -fno-common"
-IOS_CXXFLAGS="-arch ${IOS_CPU} ${MIN_VER} -stdlib=libc++ -fno-common"
+IOS_CXXFLAGS="-arch ${IOS_CPU} ${CRC} ${MIN_VER} -stdlib=libc++ -fno-common"
 IOS_SYSROOT="${XCODE_DEVELOPER_SDK}/${XCODE_SDK}"
 
 if [ ! -d "${IOS_SYSROOT}" ]; then

--- a/src/test/fipstest.cpp
+++ b/src/test/fipstest.cpp
@@ -632,7 +632,7 @@ void DoDllPowerUpSelfTest()
 
 NAMESPACE_END
 
-#ifdef CRYPTOPP_WIN32_AVAILABLE
+#if defined(CRYPTOPP_WIN32_AVAILABLE) && defined(CRYPTOPP_EXPORTS)
 
 // DllMain needs to be in the global namespace
 BOOL APIENTRY DllMain(HANDLE hModule,
@@ -647,6 +647,6 @@ BOOL APIENTRY DllMain(HANDLE hModule,
     return TRUE;
 }
 
-#endif	// #ifdef CRYPTOPP_WIN32_AVAILABLE
+#endif	// #if defined(CRYPTOPP_WIN32_AVAILABLE) && defined(CRYPTOPP_EXPORTS)
 
 #endif	// #ifndef CRYPTOPP_IMPORTS


### PR DESCRIPTION
Picks up three fixes from upstream that don't conflict with our tree:

- DllMain in fipstest.cpp is now gated on CRYPTOPP_EXPORTS, so static
  builds on Windows don't compile an unneeded DllMain. (upstream 43009744)
- TestScripts/setenv-ios.sh sets -mcrc when targeting arm64 so the
  CRC32 hardware path is available on iOS. (upstream 48d46f7b)
- Readme wording around dll.h vs static linking, for clarity.
  (upstream 6500fc83)