### PR TITLE
CVE-2023-50980 + CVE-2023-50981 defence-in-depth hardening

### DIFF
--- a/src/core/gf2n.cpp
+++ b/src/core/gf2n.cpp
@@ -948,17 +948,26 @@ GF2NP * BERDecodeGF2NP(BufferedTransformation &bt)
 {
 	member_ptr<GF2NP> result;
 
+	// Cap m to prevent allocation DoS (GH #1249); 4096 fits B-571 and the standard binary curves.
+	const unsigned int MAX_GF2N_FIELD_DEGREE = 4096;
+
 	BERSequenceDecoder seq(bt);
 		if (OID(seq) != ASN1::characteristic_two_field())
 			BERDecodeError();
 		BERSequenceDecoder parameters(seq);
 			unsigned int m;
 			BERDecodeUnsigned(parameters, m);
+			if (m == 0 || m > MAX_GF2N_FIELD_DEGREE)
+				BERDecodeError();
 			OID oid(parameters);
 			if (oid == ASN1::tpBasis())
 			{
 				unsigned int t1;
 				BERDecodeUnsigned(parameters, t1);
+				// Tighter than PolynomialMod2::Trinomial, which is relaxed for ECIES<EC2N>.
+				// DER input must be well-formed (CVE-2023-50980).
+				if (t1 == 0 || t1 >= m)
+					BERDecodeError();
 				result.reset(new GF2NT(m, t1, 0));
 			}
 			else if (oid == ASN1::ppBasis())
@@ -969,6 +978,12 @@ GF2NP * BERDecodeGF2NP(BufferedTransformation &bt)
 				BERDecodeUnsigned(pentanomial, t2);
 				BERDecodeUnsigned(pentanomial, t1);
 				pentanomial.MessageEnd();
+				// Tighter than PolynomialMod2::Pentanomial, which is relaxed for ECIES<EC2N>.
+				// DER input must be well-formed (CVE-2023-50980). SEC1 wire order is
+				// ascending, so after decoding t3 holds the smallest middle exponent
+				// and t1 the largest.
+				if (t3 == 0 || t3 >= t2 || t2 >= t1 || t1 >= m)
+					BERDecodeError();
 				result.reset(new GF2NPP(m, t3, t2, t1, 0));
 			}
 			else

--- a/src/core/nbtheory.cpp
+++ b/src/core/nbtheory.cpp
@@ -547,6 +547,10 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 	// Callers must ensure p is prime, GH #1249
 	CRYPTOPP_ASSERT(IsPrime(p));
 
+	// Cap iterations on a non-prime modulus (CVE-2023-50981).
+	// 10000 is well past what either loop needs for any practical prime.
+	const unsigned int MAX_MODULAR_SQRT_ITERATIONS = 10000;
+
 	if (p%4 == 3)
 		return a_exp_b_mod_c(a, (p+1)/4, p);
 
@@ -558,9 +562,15 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 		q >>= 1;
 	}
 
+	// Search for a quadratic non-residue.
 	Integer n=2;
+	unsigned int iters = 0;
 	while (Jacobi(n, p) != -1)
+	{
+		if (++iters > MAX_MODULAR_SQRT_ITERATIONS)
+			throw InvalidArgument("ModularSquareRoot: iteration cap exceeded (non-prime modulus)");
 		++n;
+	}
 
 	Integer y = a_exp_b_mod_c(n, q, p);
 	Integer x = a_exp_b_mod_c(a, (q-1)/2, p);
@@ -568,8 +578,13 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 	x = a*x%p;
 	Integer tempb, t;
 
+	// Outer Tonelli-Shanks step. The inner do-while is self-bounded by
+	// m == r returning early.
+	unsigned int outerIters = 0;
 	while (b != 1)
 	{
+		if (++outerIters > MAX_MODULAR_SQRT_ITERATIONS)
+			throw InvalidArgument("ModularSquareRoot: iteration cap exceeded (non-prime modulus)");
 		unsigned m=0;
 		tempb = b;
 		do

--- a/src/pubkey/rabin.cpp
+++ b/src/pubkey/rabin.cpp
@@ -132,8 +132,13 @@ void InvertibleRabinFunction::BERDecode(BufferedTransformation &bt)
 	m_u.BERDecode(seq);
 	seq.MessageEnd();
 
-	CRYPTOPP_ASSERT(IsPrime(m_p));
-	CRYPTOPP_ASSERT(IsPrime(m_q));
+	// Reject non-prime m_p/m_q at the boundary (CVE-2023-50981). They
+	// would otherwise loop forever in CalculateInverse / ModularSquareRoot.
+	// BERDecodeError, not InvalidArgument: the DER itself was fine.
+	if (!IsPrime(m_p))
+		BERDecodeError();
+	if (!IsPrime(m_q))
+		BERDecodeError();
 }
 
 void InvertibleRabinFunction::DEREncode(BufferedTransformation &bt) const

--- a/src/test/validat6.cpp
+++ b/src/test/validat6.cpp
@@ -343,6 +343,124 @@ bool ValidateECP()
 	return ValidateECP_Agreement() && ValidateECP_Encrypt() && ValidateECP_NULLDigest_Encrypt() && ValidateECP_Sign() && pass;
 }
 
+// Helpers for TestBERDecodeGF2NPHardening (CVE-2023-50980, GH #1249).
+
+static void EncodeGF2NPTrinomial(ByteQueue& out, unsigned int m, unsigned int t1)
+{
+	DERSequenceEncoder seq(out);
+		ASN1::characteristic_two_field().DEREncode(seq);
+		DERSequenceEncoder parameters(seq);
+			DEREncodeUnsigned(parameters, m);
+			ASN1::tpBasis().DEREncode(parameters);
+			DEREncodeUnsigned(parameters, t1);
+		parameters.MessageEnd();
+	seq.MessageEnd();
+}
+
+static void EncodeGF2NPPentanomial(ByteQueue& out, unsigned int m,
+	unsigned int k1, unsigned int k2, unsigned int k3)
+{
+	// SEC1 pentanomial: 0 < k1 < k2 < k3 < m, encoded ascending in DER.
+	DERSequenceEncoder seq(out);
+		ASN1::characteristic_two_field().DEREncode(seq);
+		DERSequenceEncoder parameters(seq);
+			DEREncodeUnsigned(parameters, m);
+			ASN1::ppBasis().DEREncode(parameters);
+			DERSequenceEncoder pp(parameters);
+				DEREncodeUnsigned(pp, k1);
+				DEREncodeUnsigned(pp, k2);
+				DEREncodeUnsigned(pp, k3);
+			pp.MessageEnd();
+		parameters.MessageEnd();
+	seq.MessageEnd();
+}
+
+static bool ExpectGF2NPDecodeRejected(ByteQueue& q, const char *label)
+{
+	bool threw = false;
+	try
+	{
+		member_ptr<GF2NP> result(BERDecodeGF2NP(q));
+		(void)result;
+	}
+	catch (const Exception&)
+	{
+		threw = true;
+	}
+
+	std::cout << (threw ? "passed    " : "FAILED    ") << label << "\n";
+	return threw;
+}
+
+static bool ExpectGF2NPDecodeAccepted(ByteQueue& q, const char *label)
+{
+	bool ok = false;
+	try
+	{
+		member_ptr<GF2NP> field(BERDecodeGF2NP(q));
+		// Square x; non-zero confirms the field is usable.
+		PolynomialMod2 x((word)0, 3);
+		x.SetBit(1);
+		ok = !field->Square(x).IsZero();
+	}
+	catch (const Exception&) {}
+
+	std::cout << (ok ? "passed    " : "FAILED    ") << label << "\n";
+	return ok;
+}
+
+bool TestBERDecodeGF2NPHardening()
+{
+	std::cout << "\nBERDecodeGF2NP hardening tests running...\n\n";
+	bool pass = true;
+
+	// Invalid cases. BERDecodeGF2NP must reject.
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 0, 0);
+		pass = ExpectGF2NPDecodeRejected(q, "m = 0 (trinomial)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 4097, 27);
+		pass = ExpectGF2NPDecodeRejected(q, "m = 4097 (one over the cap)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 8192, 27);
+		pass = ExpectGF2NPDecodeRejected(q, "m = 8192 (over cap)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 233, 0);
+		pass = ExpectGF2NPDecodeRejected(q, "trinomial t1 = 0") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 233, 233);
+		pass = ExpectGF2NPDecodeRejected(q, "trinomial t1 = m (not strictly less)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPPentanomial(q, 233, 0, 6, 74);
+		pass = ExpectGF2NPDecodeRejected(q, "pentanomial k1 = 0") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPPentanomial(q, 233, 10, 200, 200);
+		pass = ExpectGF2NPDecodeRejected(q, "pentanomial k2 = k3 (not strictly ordered)") && pass;
+	}
+
+	// Valid cases. Must decode and the field must be usable.
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 233, 74);
+		pass = ExpectGF2NPDecodeAccepted(q, "m = 233, t1 = 74 (SECT233R1)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPTrinomial(q, 4096, 27);
+		pass = ExpectGF2NPDecodeAccepted(q, "m = 4096 (at the cap)") && pass;
+	}
+	{
+		ByteQueue q; EncodeGF2NPPentanomial(q, 163, 3, 6, 7);
+		pass = ExpectGF2NPDecodeAccepted(q, "m = 163, k1=3, k2=6, k3=7 (SECT163K1)") && pass;
+	}
+
+	return pass;
+}
+
 bool ValidateEC2N()
 {
 	// Remove word recommend. Binary curves may not be recommended depending
@@ -377,6 +495,7 @@ bool ValidateEC2N()
 #endif
 
 	std::cout << "\nEC2N validation suite running...\n\n";
+	pass = TestBERDecodeGF2NPHardening() && pass;
 	return ValidateEC2N_Agreement() && ValidateEC2N_Encrypt() && ValidateEC2N_Sign() && pass;
 }
 

--- a/src/test/validat8.cpp
+++ b/src/test/validat8.cpp
@@ -12,6 +12,7 @@
 
 #include <cryptopp/asn.h>
 #include <cryptopp/oids.h>
+#include <cryptopp/nbtheory.h>
 
 #include <cryptopp/luc.h>
 #include <cryptopp/rsa.h>
@@ -396,11 +397,51 @@ static bool TestRabinBERDecodePrimality()
 	return pass;
 }
 
+static bool TestModularSquareRootCap()
+{
+	std::cout << "\nModularSquareRoot iteration cap tests running...\n\n";
+	bool pass = true;
+
+	// p = 9 (non-prime perfect square). Jacobi(n, 9) = (n/3)^2 >= 0 for
+	// all n coprime to 9, so the non-residue search runs to the cap.
+	{
+		bool threw = false;
+		try
+		{
+			ModularSquareRoot(Integer(4), Integer(9));
+		}
+		catch (const InvalidArgument&)
+		{
+			threw = true;
+		}
+		std::cout << (threw ? "passed    " : "FAILED    ") << "p = 9 (non-prime) trips the cap\n";
+		pass = threw && pass;
+	}
+
+	// Regression with prime p where p%4 != 3, so the (p+1)/4 shortcut does
+	// not apply and the non-residue search and Tonelli-Shanks step both run.
+	{
+		const Integer p(17), a(4);
+		bool ok = false;
+		try
+		{
+			Integer x = ModularSquareRoot(a, p);
+			ok = (x.Squared() % p == a);
+		}
+		catch (const Exception&) {}
+		std::cout << (ok ? "passed    " : "FAILED    ") << "p = 17, sqrt(4) round-trips\n";
+		pass = ok && pass;
+	}
+
+	return pass;
+}
+
 bool ValidateRabin_Encrypt()
 {
 	bool pass = true, fail;
 
 	pass = TestRabinBERDecodePrimality() && pass;
+	pass = TestModularSquareRootCap() && pass;
 
 #if defined(CRYPTOPP_EXTENDED_VALIDATION)
 	{

--- a/src/test/validat8.cpp
+++ b/src/test/validat8.cpp
@@ -312,9 +312,95 @@ bool ValidateLUC_DL_Encrypt()
 	return CryptoSystemValidate(privC, pubC);
 }
 
+static bool TestRabinBERDecodePrimality()
+{
+	std::cout << "\nRabin BERDecode primality tests running...\n\n";
+	bool pass = true;
+
+	// Non-prime m_p. BERDecode must reject.
+	{
+		ByteQueue q;
+		DERSequenceEncoder seq(q);
+			Integer(63).DEREncode(seq);  // m_n
+			Integer(2).DEREncode(seq);   // m_r
+			Integer(3).DEREncode(seq);   // m_s
+			Integer(9).DEREncode(seq);   // m_p, non-prime
+			Integer(7).DEREncode(seq);   // m_q, prime
+			Integer(1).DEREncode(seq);   // m_u
+		seq.MessageEnd();
+
+		bool threw = false;
+		try
+		{
+			InvertibleRabinFunction key;
+			key.BERDecode(q);
+		}
+		catch (const Exception&)
+		{
+			threw = true;
+		}
+
+		std::cout << (threw ? "passed    " : "FAILED    ") << "non-prime m_p rejected\n";
+		pass = threw && pass;
+	}
+
+	// Non-prime m_q. BERDecode must reject.
+	{
+		ByteQueue q;
+		DERSequenceEncoder seq(q);
+			Integer(63).DEREncode(seq);  // m_n
+			Integer(2).DEREncode(seq);   // m_r
+			Integer(3).DEREncode(seq);   // m_s
+			Integer(7).DEREncode(seq);   // m_p, prime
+			Integer(9).DEREncode(seq);   // m_q, non-prime
+			Integer(1).DEREncode(seq);   // m_u
+		seq.MessageEnd();
+
+		bool threw = false;
+		try
+		{
+			InvertibleRabinFunction key;
+			key.BERDecode(q);
+		}
+		catch (const Exception&)
+		{
+			threw = true;
+		}
+
+		std::cout << (threw ? "passed    " : "FAILED    ") << "non-prime m_q rejected\n";
+		pass = threw && pass;
+	}
+
+	// Valid round-trip: rabi1024.dat -> DEREncode -> BERDecode.
+	{
+		bool ok = false;
+		try
+		{
+			FileSource keys(DataDir("TestData/rabi1024.dat").c_str(), true, new HexDecoder);
+			InvertibleRabinFunction priv;
+			priv.BERDecode(keys);
+
+			ByteQueue q;
+			priv.DEREncode(q);
+
+			InvertibleRabinFunction priv2;
+			priv2.BERDecode(q);
+			ok = true;
+		}
+		catch (const Exception&) {}
+
+		std::cout << (ok ? "passed    " : "FAILED    ") << "valid Rabin key round-trip\n";
+		pass = ok && pass;
+	}
+
+	return pass;
+}
+
 bool ValidateRabin_Encrypt()
 {
 	bool pass = true, fail;
+
+	pass = TestRabinBERDecodePrimality() && pass;
 
 #if defined(CRYPTOPP_EXTENDED_VALIDATION)
 	{


### PR DESCRIPTION
## Summary

Follow-up to #21. The published PoCs for these CVEs were already mitigated in 2025.11.0, but reviewing the same code paths turned up a few places where malformed input could still get further than it should before being rejected.

I do not believe these are exploitable based on the current code paths, but they are still worth tightening up.

This PR includes three commits:

### BERDecodeGF2NP (CVE-2023-50980)

Validates the trinomial / pentanomial ordering at decode time instead of assuming it is already sane:

- trinomial: `0 < t1 < m`
- pentanomial: `0 < t1 < t2 < t3 < m`

Also caps the field degree at `MAX_GF2N_FIELD_DEGREE = 4096`.

That is already well beyond realistic `F(2^m)` use in this code, but if a legitimate use case needs more, the cap can be revisited.

### InvertibleRabinFunction::BERDecode (CVE-2023-50981)

The `IsPrime` checks on `m_p` and `m_q` were debug-only asserts, so they did not protect release builds.

This promotes those checks to runtime `BERDecodeError` validation.

### ModularSquareRoot iteration cap (CVE-2023-50981)

Bounds the non-residue search and the outer Tonelli-Shanks loop at `10000` iterations.

If the cap is reached, `InvalidArgument` is thrown. For valid prime moduli, this should not get close to the cap in normal use.

## Test plan

- [x] `cryptest.exe v 21` and `cryptest.exe v 24` clean
- [x] 14 new cases added
- [x] No regression in Rabin / EC2N / ECP suites
- [x ] CI matrix: GCC, Clang, MSVC, macOS, ASan, UBSan, no-ASM

Closes #21
