### PR TITLE
Clean up Clang warnings reported in #24

### DIFF
--- a/include/cryptopp/blake3.h
+++ b/include/cryptopp/blake3.h
@@ -199,7 +199,6 @@ private:
 	State m_state;
 	AlignedSecByteBlock m_keyBytes;
 	word32 m_digestSize;
-	bool m_treeMode;
 };
 
 NAMESPACE_END

--- a/include/cryptopp/misc.h
+++ b/include/cryptopp/misc.h
@@ -152,7 +152,7 @@ class Integer;
 ///  a negative-sized array triggers the assert at compile time.
 # define CRYPTOPP_COMPILE_ASSERT(expr) { ... }
 #elif defined(CRYPTOPP_CXX17_STATIC_ASSERT)
-# define CRYPTOPP_COMPILE_ASSERT(expr) static_assert(expr)
+# define CRYPTOPP_COMPILE_ASSERT(expr) static_assert(expr, #expr)
 #else // CRYPTOPP_DOXYGEN_PROCESSING
 template <bool b>
 struct CompileAssert

--- a/src/hash/blake3.cpp
+++ b/src/hash/blake3.cpp
@@ -365,7 +365,7 @@ std::string BLAKE3::AlgorithmProvider() const
 // Constructors
 
 BLAKE3::BLAKE3(unsigned int digestSize)
-	: m_digestSize(digestSize), m_treeMode(false)
+	: m_digestSize(digestSize)
 {
 	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
 	m_state.Reset();
@@ -377,7 +377,7 @@ BLAKE3::BLAKE3(unsigned int digestSize)
 }
 
 BLAKE3::BLAKE3(const byte *key, size_t keyLength, unsigned int digestSize)
-	: m_digestSize(digestSize), m_treeMode(false)
+	: m_digestSize(digestSize)
 {
 	CRYPTOPP_ASSERT(keyLength == 32);
 	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
@@ -398,7 +398,7 @@ BLAKE3::BLAKE3(const byte *key, size_t keyLength, unsigned int digestSize)
 }
 
 BLAKE3::BLAKE3(const char* context, unsigned int digestSize)
-	: m_digestSize(digestSize), m_treeMode(false)
+	: m_digestSize(digestSize)
 {
 	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
 

--- a/src/pqc/mldsa.cpp
+++ b/src/pqc/mldsa.cpp
@@ -18,11 +18,6 @@
 NAMESPACE_BEGIN(CryptoPP)
 NAMESPACE_BEGIN(MLDSA_Internal)
 
-// ==================== Constants ====================
-
-// SHAKE256 block size for challenge generation
-static constexpr unsigned int SHAKE256_BLOCKSIZE = 136;
-
 // ==================== NTT Zetas ====================
 
 // Precomputed powers of the primitive 512th root of unity in Montgomery form
@@ -771,8 +766,6 @@ template void poly_unpack_z<Params_87>(poly *r, const byte *a);
 // ==================== W1 Packing ====================
 
 // gamma2 values: (MLDSA_Q - 1) / 88 = 95232, (MLDSA_Q - 1) / 32 = 261888
-static const int32_t GAMMA2_DIV88 = (MLDSA_Q - 1) / 88;  // 95232
-static const int32_t GAMMA2_DIV32 = (MLDSA_Q - 1) / 32;  // 261888
 
 // Helper for gamma2-based W1 packing (6-bit vs 4-bit)
 template <int32_t GAMMA2>

--- a/src/pqc/slhdsa.cpp
+++ b/src/pqc/slhdsa.cpp
@@ -525,9 +525,7 @@ static void slh_sign(byte *sig, const byte *msg, size_t msg_len,
     constexpr unsigned int K = InternalParams::fors_trees;
     constexpr unsigned int A = InternalParams::fors_height;
     constexpr unsigned int H = InternalParams::h;
-    constexpr unsigned int D = InternalParams::d;
     constexpr unsigned int HP = InternalParams::hp;
-    constexpr unsigned int LEN = InternalParams::wots_len;
 
     // Parse secret key
     const byte *sk_seed = sk;
@@ -599,7 +597,6 @@ static bool slh_verify(const byte *msg, size_t msg_len,
     constexpr unsigned int K = InternalParams::fors_trees;
     constexpr unsigned int A = InternalParams::fors_height;
     constexpr unsigned int H = InternalParams::h;
-    constexpr unsigned int D = InternalParams::d;
     constexpr unsigned int HP = InternalParams::hp;
 
     // Parse public key

--- a/src/pqc/slhdsa_fors.h
+++ b/src/pqc/slhdsa_fors.h
@@ -24,8 +24,6 @@ template <class HASH_CTX, class PARAMS>
 void fors_sk_gen(byte *sk, const byte *sk_seed,
                         const byte *pub_seed, byte *addr, uint32_t idx)
 {
-    constexpr unsigned int N = PARAMS::n;
-
     // Set address for FORS PRF
     // Per FIPS 205 Algorithm 10: setTypeAndClear, then restore keypair
     byte sk_addr[ADDR_BYTES];

--- a/src/test/validat1.cpp
+++ b/src/test/validat1.cpp
@@ -1051,7 +1051,10 @@ bool TestHuffmanCodes()
             LowFirstBitReader reader(source);
             unsigned int val;
             for (unsigned int j=0; !source.AnyRetrievable(); ++j)
+            {
                 decoder.Decode(reader, val);
+                (void)j;
+            }
         }
         catch (const Exception&) {}
     }


### PR DESCRIPTION
## Summary

Closes #24, reported by @jolaf on AppleClang 21.

This PR cleans up the three warning groups from the issue:

- **`4162fb63` Remove unused declarations flagged by Clang**  
  Removes eight unused declarations across BLAKE3, ML-DSA and SLH-DSA.

- **`9f1c8bb6` Suppress -Wunused-but-set-variable in TestHuffmanCodes**  
  Adds `(void)j;` for the unread loop counter, keeping the upstream loop shape and matching the existing pattern at `validat6.cpp:384`.

- **`5403744f` Use two-argument static_assert in CRYPTOPP_COMPILE_ASSERT**  
  Replaces C++17-only `static_assert(expr)` with the C++11-compatible `static_assert(expr, #expr)` across the existing macro uses.

No runtime behaviour change. C++17 and later consumers should only see a different message if a static assertion fails.

The `static_assert` fix is inherited from upstream Crypto++ and may be worth filing there as a small follow-up.

## Test plan

- [x] Clang 22.1.0 at `-std=c++14` with the issue #24 warning flags: clean on `blake3.cpp`, `mldsa.cpp`, `slhdsa.cpp`
- [x] MinGW GCC 14.2.0 full library + cryptest build: clean
- [x] BLAKE3 test vectors: 5/5 pass locally
- [x] CI: GCC 11-14, Clang 15-19, MSVC, macOS, ASan, UBSan, no-ASM, AVX512