### PR TITLE
Fix BLAKE3 NEON rot8 build on armv7

### DIFF
--- a/src/hash/blake3_simd.cpp
+++ b/src/hash/blake3_simd.cpp
@@ -1064,11 +1064,21 @@ inline uint32x4_t rot12_neon(uint32x4_t x) {
     return veorq_u32(vshrq_n_u32(x, 12), vshlq_n_u32(x, 20));
 }
 
-// Rotation by 8 bits
+// Rotation by 8 bits.
+// Three-branch form matches the BLAKE3 reference and avoids vqtbl1q_u8,
+// which is AArch64-only, so armv7 NEON builds compile.
 inline uint32x4_t rot8_neon(uint32x4_t x) {
-    return vreinterpretq_u32_u8(vqtbl1q_u8(
-        vreinterpretq_u8_u32(x),
-        (uint8x16_t){1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12}));
+#if defined(__clang__)
+    return vreinterpretq_u32_u8(__builtin_shufflevector(
+        vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x),
+        1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12));
+#elif defined(__GNUC__) && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 >= 40700)
+    static const uint8x16_t r8 = {1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12};
+    return vreinterpretq_u32_u8(__builtin_shuffle(
+        vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), r8));
+#else
+    return vsriq_n_u32(vshlq_n_u32(x, 32 - 8), x, 8);
+#endif
 }
 
 // Rotation by 7 bits


### PR DESCRIPTION
## Summary

Fixes the armv7 NEON build of `blake3_simd.cpp`.

`rot8_neon` used `vqtbl1q_u8`, which is AArch64-only. armv7 NEON only supports VTBL with 8-byte inputs.

Replace it with the BLAKE3 reference approach: Clang `__builtin_shufflevector`, GCC 4.7+ `__builtin_shuffle`, and a `vsriq_n_u32` fallback.

On AArch64, Clang and GCC still lower this to `TBL`, with bit-identical output to the previous path.

The remaining `cpu-features.h` item in #27 is a separate upstream-inherited CMake gap and will be handled separately.

## Verification

- Clean cross-compile on `armv7-linux-gnueabihf` and `aarch64-linux-gnu` with LLVM 22.
- Clean host build.
- `cryptest.exe v` passed.
- `cryptest.exe v 88` BLAKE3 KATs passed: 5/5.

Refs: #27