### PR TITLE
Android cpu-features and add Android CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -224,6 +224,42 @@ jobs:
         ./build/test-app
 
   # =============================================================================
+  # CMake Android Cross-compile (build-only, no emulator)
+  # =============================================================================
+
+  cmake-android-arm64-v8a:
+    name: CMake Android (arm64-v8a)
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (Android arm64-v8a)
+      run: cmake --preset=ci-android-arm64-v8a
+
+    - name: Build cryptopp library
+      run: cmake --build build/ci-android-arm64-v8a --target cryptopp -j"$(nproc)"
+
+  cmake-android-armeabi-v7a:
+    name: CMake Android (armeabi-v7a)
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (Android armeabi-v7a)
+      run: cmake --preset=ci-android-armeabi-v7a
+
+    - name: Build cryptopp library
+      run: cmake --build build/ci-android-armeabi-v7a --target cryptopp -j"$(nproc)"
+
+  # =============================================================================
   # Makefile Builds (Backward Compatibility)
   # =============================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1062,6 +1062,20 @@ if(NOT has_disable_asm EQUAL -1)
     list(PREPEND cryptopp_SOURCES "${cryptopp_SOURCE_DIR}/src/core/sse_simd.cpp")
 endif()
 
+# Adjust for Android: stage NDK cpu-features. Same shape as cryptopp-cmake/sources.cmake.
+if(ANDROID)
+    set(_cpufeatures_dir "${ANDROID_NDK}/sources/android/cpufeatures")
+    if(EXISTS "${_cpufeatures_dir}/cpu-features.h"
+       AND EXISTS "${_cpufeatures_dir}/cpu-features.c")
+        include_directories("${_cpufeatures_dir}")
+        list(APPEND cryptopp_SOURCES "${_cpufeatures_dir}/cpu-features.c")
+        message(STATUS "[cryptopp-modern] Staging NDK cpufeatures from ${_cpufeatures_dir}")
+    else()
+        message(WARNING "Android build but cpu-features not found at ${_cpufeatures_dir}. Set ANDROID_NDK or copy the files into the build manually.")
+    endif()
+    unset(_cpufeatures_dir)
+endif()
+
 # Apply compiler options to SIMD source files
 set_source_files_properties(
     ${cryptopp_SOURCE_DIR}/src/symmetric/aria.cpp

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -103,6 +103,32 @@
       }
     },
     {
+      "name": "ci-android-arm64-v8a",
+      "displayName": "CI Android arm64-v8a",
+      "description": "Cross-compile for Android arm64-v8a via NDK toolchain",
+      "inherits": "default",
+      "toolchainFile": "$env{ANDROID_NDK_LATEST_HOME}/build/cmake/android.toolchain.cmake",
+      "cacheVariables": {
+        "ANDROID_ABI": "arm64-v8a",
+        "ANDROID_PLATFORM": "android-24",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CRYPTOPP_BUILD_TESTING": "OFF"
+      }
+    },
+    {
+      "name": "ci-android-armeabi-v7a",
+      "displayName": "CI Android armeabi-v7a",
+      "description": "Cross-compile for Android armeabi-v7a via NDK toolchain",
+      "inherits": "default",
+      "toolchainFile": "$env{ANDROID_NDK_LATEST_HOME}/build/cmake/android.toolchain.cmake",
+      "cacheVariables": {
+        "ANDROID_ABI": "armeabi-v7a",
+        "ANDROID_PLATFORM": "android-24",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CRYPTOPP_BUILD_TESTING": "OFF"
+      }
+    },
+    {
       "name": "no-asm",
       "displayName": "No ASM",
       "description": "Build without assembly optimizations",


### PR DESCRIPTION
 ## Summary

  Closes the remaining work from #27. PR #28 fixed the BLAKE3 armv7 NEON issue, this one covers the follow-up CMake and CI work.

  - Stages Android NDK `cpu-features` for CMake builds by adding the NDK `cpufeatures` directory and `cpu-features.c` when `ANDROID` is set.

  - Adds build-only Android CI jobs for `arm64-v8a` and `armeabi-v7a`. No emulator step; this is just to catch Android build-path regressions.

  ## Verification

  Host build passes cleanly.

  Android cross-compile is covered by the new CI jobs.

  Refs: #27