### PR TITLE
Bump actions/checkout to v5 and add legacy compiler CI jobs

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -251,6 +251,66 @@ jobs:
     - name: Run test vectors
       run: ./cryptest.exe tv all
 
+  makefile-linux-gcc-legacy:
+    name: Makefile Linux GCC ${{ matrix.gcc-version }} (Legacy)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc-version: [9, 10]
+        cxx-standard: [14, 17]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install GCC ${{ matrix.gcc-version }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}
+
+    - name: Build library (C++${{ matrix.cxx-standard }})
+      run: |
+        export CXX=g++-${{ matrix.gcc-version }}
+        export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }}"
+        make clean
+        make -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./cryptest.exe v
+
+    - name: Run test vectors
+      run: ./cryptest.exe tv all
+
+  makefile-linux-clang-legacy:
+    name: Makefile Linux Clang ${{ matrix.clang-version }} (Legacy)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        clang-version: [13, 14]
+        cxx-standard: [14, 17]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Clang ${{ matrix.clang-version }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-${{ matrix.clang-version }}
+
+    - name: Build library (C++${{ matrix.cxx-standard }})
+      run: |
+        export CXX=clang++-${{ matrix.clang-version }}
+        export CXXFLAGS="-DNDEBUG -g2 -O3 -std=c++${{ matrix.cxx-standard }}"
+        make clean
+        make -j"$(nproc)"
+
+    - name: Run validation tests
+      run: ./cryptest.exe v
+
+    - name: Run test vectors
+      run: ./cryptest.exe tv all
+
   makefile-linux-clang-old:
     name: Makefile Linux Clang ${{ matrix.clang-version }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC 14 and Ninja
       run: |
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang 19 and Ninja
       run: |
@@ -101,7 +101,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: brew install ninja
@@ -123,7 +123,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Configure
       run: cmake --preset=ci-windows
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -230,7 +230,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC ${{ matrix.gcc-version }}
       run: |
@@ -261,7 +261,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang ${{ matrix.clang-version }}
       run: |
@@ -293,7 +293,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang ${{ matrix.clang-version }}
       run: |
@@ -322,7 +322,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build library (C++${{ matrix.cxx-standard }})
       run: |
@@ -346,7 +346,7 @@ jobs:
         configuration: [Release]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -375,7 +375,7 @@ jobs:
         sanitizer: [ubsan, asan]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC 13
       run: |
@@ -410,7 +410,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Check CPU features
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC 14 and Ninja
       run: |
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang 19 and Ninja
       run: |
@@ -108,7 +108,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: brew install ninja
@@ -130,7 +130,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Configure
       run: cmake --preset=ci-windows
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Ninja
       run: sudo apt-get update && sudo apt-get install -y ninja-build
@@ -273,7 +273,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC ${{ matrix.gcc-version }}
       run: |
@@ -304,7 +304,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang ${{ matrix.clang-version }}
       run: |
@@ -336,7 +336,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Clang ${{ matrix.clang-version }}
       run: |
@@ -365,7 +365,7 @@ jobs:
         cxx-standard: [14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build library (C++${{ matrix.cxx-standard }})
       run: |
@@ -389,7 +389,7 @@ jobs:
         configuration: [Release]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -418,7 +418,7 @@ jobs:
         sanitizer: [ubsan, asan]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install GCC 13
       run: |
@@ -453,7 +453,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Check CPU features
       run: |


### PR DESCRIPTION
## Summary

Two small CI clean-ups.

- Bump `actions/checkout` from v4 to v5 across both workflow files, removing the Node.js 20 deprecation warnings before GitHub Actions moves JavaScript actions to Node.js 24 by default on 2 June 2026.

- Add legacy compiler jobs for GCC 9, GCC 10, Clang 13, and Clang 14 in `branch-build-and-test.yml`. These run on `ubuntu-22.04`, where those older compilers are still available.

The legacy jobs run the normal `cryptest` flow and move the coverage from the LMS branch into main, so every PR gets it.

## Verification

CI covers this PR directly:

- existing jobs now use `actions/checkout@v5`
- new jobs build and run `cryptest` with GCC 9/10 and Clang 13/14