### PR TITLE
Harden DERReencode and Ed25519 verification

### DIFF
--- a/src/core/asn.cpp
+++ b/src/core/asn.cpp
@@ -268,8 +268,14 @@ size_t BERDecodeBitString(BufferedTransformation &bt, SecByteBlock &str, unsigne
 	return bc-1;
 }
 
-void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
+// Max nested constructed BER depth, matching OpenSSL ASN1_MAX_CONSTRUCTED_NEST.
+// See weidai11/cryptopp#1353.
+static const unsigned int DER_REENCODE_MAX_DEPTH = 32;
+
+static void DERReencodeLimited(BufferedTransformation &source, BufferedTransformation &dest, unsigned int depth)
 {
+	if (depth >= DER_REENCODE_MAX_DEPTH)
+		BERDecodeError();
 	byte tag;
 	source.Peek(tag);
 	BERGeneralDecoder decoder(source, tag);
@@ -279,10 +285,15 @@ void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
 	else
 	{
 		while (!decoder.EndReached())
-			DERReencode(decoder, encoder);
+			DERReencodeLimited(decoder, encoder, depth + 1);
 	}
 	decoder.MessageEnd();
 	encoder.MessageEnd();
+}
+
+void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
+{
+	DERReencodeLimited(source, dest, 0);
 }
 
 size_t BERDecodePeekLength(const BufferedTransformation &bt)

--- a/src/core/tweetnacl.cpp
+++ b/src/core/tweetnacl.cpp
@@ -886,6 +886,17 @@ static int unpackneg(gf r[4],const byte p[32])
   return 0;
 }
 
+/* Reject S >= L per RFC 8032. See weidai11/cryptopp#1352. */
+static int scalar_is_canonical(const byte s[32])
+{
+  int i;
+  for(i=31; i>=0; --i) {
+    if (s[i] < L[i]) return 1;
+    if (s[i] > L[i]) return 0;
+  }
+  return 0;
+}
+
 int crypto_sign_open(byte *m,word64 *mlen,const byte *sm,word64 n,const byte *pk)
 {
   word32 i;
@@ -895,6 +906,7 @@ int crypto_sign_open(byte *m,word64 *mlen,const byte *sm,word64 n,const byte *pk
   *mlen = ~W64LIT(0);
   if (n < 64) return -1;
 
+  if (!scalar_is_canonical(sm + 32)) return -1;
   if (unpackneg(q,pk)) return -1;
 
   for(i=0; i<n; ++i) m[i] = sm[i];

--- a/src/pubkey/donna_32.cpp
+++ b/src/pubkey/donna_32.cpp
@@ -519,6 +519,22 @@ ed25519_pubkey_is_canonical(const byte pk[32]) {
     return pk[0] < 0xed;
 }
 
+/* Reject S >= L (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_scalar_is_canonical(const byte S[32]) {
+    static const byte L[32] = {
+        0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+        0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10
+    };
+    for (int i = 31; i >= 0; --i) {
+        if (S[i] < L[i]) return true;
+        if (S[i] > L[i]) return false;
+    }
+    return false;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -2047,7 +2063,7 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ed25519_pubkey_is_canonical(pk) ||
         !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
@@ -2076,7 +2092,7 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ed25519_pubkey_is_canonical(pk) ||
         !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 

--- a/src/pubkey/donna_64.cpp
+++ b/src/pubkey/donna_64.cpp
@@ -447,6 +447,22 @@ ed25519_pubkey_is_canonical(const byte pk[32]) {
     return pk[0] < 0xed;
 }
 
+/* Reject S >= L (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_scalar_is_canonical(const byte S[32]) {
+    static const byte L[32] = {
+        0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+        0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10
+    };
+    for (int i = 31; i >= 0; --i) {
+        if (S[i] < L[i]) return true;
+        if (S[i] > L[i]) return false;
+    }
+    return false;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -1760,7 +1776,7 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ed25519_pubkey_is_canonical(pk) ||
         !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
@@ -1789,7 +1805,7 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ed25519_pubkey_is_canonical(pk) ||
         !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 

--- a/src/test/validat0.cpp
+++ b/src/test/validat0.cpp
@@ -1607,6 +1607,44 @@ bool TestASN1Functions()
     }
 
     {
+        // Issue weidai11/cryptopp#1353. 32 levels accept, 33 first throw,
+        // 10000 confirms no crash past the cap.
+        const unsigned int probes[] = {8, 32, 33, 10000};
+        const bool expectThrow[] = {false, false, true, true};
+        unsigned int failed = 0;
+
+        for (size_t i = 0; i < COUNTOF(probes); ++i)
+        {
+            std::string payload;
+            payload.reserve(static_cast<size_t>(probes[i]) * 4);
+            for (unsigned int d = 0; d < probes[i]; ++d) {
+                payload.push_back('\x30');
+                payload.push_back('\x80');
+            }
+            for (unsigned int d = 0; d < probes[i]; ++d) {
+                payload.push_back('\x00');
+                payload.push_back('\x00');
+            }
+
+            ByteQueue src, dst;
+            src.Put(ConstBytePtr(payload), BytePtrSize(payload));
+
+            bool threw = false;
+            try { DERReencode(src, dst); }
+            catch (const Exception&) { threw = true; }
+
+            if (threw != expectThrow[i]) ++failed;
+        }
+
+        failed ? fail = true : fail = false;
+        pass = pass && !fail;
+        CRYPTOPP_ASSERT(!fail);
+
+        std::cout << (fail ? "FAILED" : "passed") << "  ";
+        std::cout << "DERReencode depth cap (Issue 1353)" << "\n";
+    }
+
+    {
         const byte date[] = "Sun, 21 Mar 2021 01:00:00 +0000";
         SecByteBlock message; message.Assign(date, sizeof(date)-1);
         const byte asnDateTypes[] = {UTC_TIME, GENERALIZED_TIME};

--- a/src/test/validat7.cpp
+++ b/src/test/validat7.cpp
@@ -698,6 +698,89 @@ bool TestEd25519()
 	std::cout << (fail ? "FAILED" : "passed") << "  ";
 	std::cout << "RFC 5208 and 5958 key loads" << std::endl;
 
+	// Issue weidai11/cryptopp#1352. Verifier must reject S >= L per RFC 8032.
+	// Smoking gun is the S' + L mutation; boundary scalars guard the predicate.
+	static const byte L[32] = {
+		0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+		0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10
+	};
+
+	try {
+		ed25519Signer signer(GlobalRNG());
+		ed25519Verifier verifier(signer);
+
+		const byte msg[] = {'t','e','s','t'};
+		byte original[64];
+		signer.SignMessage(GlobalRNG(), msg, sizeof(msg), original);
+
+		// Control: original signature must verify.
+		bool control = verifier.VerifyMessage(msg, sizeof(msg),
+			original, sizeof(original));
+
+		// Reporter's PoC: replace S with original_S + L.
+		byte plusL[64];
+		std::memcpy(plusL, original, 64);
+		{
+			unsigned int carry = 0;
+			for (int i = 0; i < 32; ++i) {
+				unsigned int v = plusL[32 + i] + L[i] + carry;
+				plusL[32 + i] = static_cast<byte>(v);
+				carry = v >> 8;
+			}
+		}
+		bool s_plus_l = verifier.VerifyMessage(msg, sizeof(msg),
+			plusL, sizeof(plusL));
+
+		// Boundary scalars. R stays valid; only S is mutated.
+		const byte scalars[5][32] = {
+			// S = L
+			{ 0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+			  0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+			  0,0,0,0, 0,0,0,0,
+			  0,0,0,0, 0,0,0,0x10 },
+			// S = L + 1
+			{ 0xee,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+			  0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+			  0,0,0,0, 0,0,0,0,
+			  0,0,0,0, 0,0,0,0x10 },
+			// S = 2^253 - 1
+			{ 0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0x1f },
+			// S = 2^253
+			{ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
+			  0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0x20 },
+			// S = 2^256 - 1
+			{ 0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff,
+			  0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff }
+		};
+
+		unsigned int accepted = 0;
+		for (size_t i = 0; i < COUNTOF(scalars); ++i) {
+			byte boundary[64];
+			std::memcpy(boundary, original, 32);
+			std::memcpy(boundary + 32, scalars[i], 32);
+			if (verifier.VerifyMessage(msg, sizeof(msg),
+					boundary, sizeof(boundary)))
+				++accepted;
+		}
+
+		fail = !control || s_plus_l || accepted != 0;
+	}
+	catch (const Exception&) {
+		fail = true;
+	}
+
+	pass = pass && !fail;
+
+	std::cout << (fail ? "FAILED" : "passed") << "  ";
+	std::cout << "Ed25519 scalar canonicality (Issue 1352)" << std::endl;
+
 	return pass;
 }
 

--- a/src/test/validat7.cpp
+++ b/src/test/validat7.cpp
@@ -781,6 +781,49 @@ bool TestEd25519()
 	std::cout << (fail ? "FAILED" : "passed") << "  ";
 	std::cout << "Ed25519 scalar canonicality (Issue 1352)" << std::endl;
 
+	// Issue weidai11/cryptopp#1352 (NaCl path). S' + L mutation must reject.
+#ifndef CRYPTOPP_DISABLE_NACL
+	try {
+		byte pk[NaCl::crypto_sign_PUBLICKEYBYTES];
+		byte sk[NaCl::crypto_sign_SECRETKEYBYTES];
+		(void)NaCl::crypto_sign_keypair(pk, sk);
+
+		const byte msg[] = {'t','e','s','t'};
+		byte sm[64 + sizeof(msg)];
+		word64 smlen = sizeof(sm);
+		int ret1 = NaCl::crypto_sign(sm, &smlen, msg, sizeof(msg), sk);
+
+		// Control: signed message must verify.
+		byte recovered[64 + sizeof(msg)];
+		word64 mlen = sizeof(recovered);
+		int ret2 = NaCl::crypto_sign_open(recovered, &mlen, sm, smlen, pk);
+
+		// Mutate S in place: sm[0..32]=R, sm[32..64]=S, sm[64..]=msg.
+		{
+			unsigned int carry = 0;
+			for (int i = 0; i < 32; ++i) {
+				unsigned int v = sm[32 + i] + L[i] + carry;
+				sm[32 + i] = static_cast<byte>(v);
+				carry = v >> 8;
+			}
+		}
+
+		// Mutated signature: must reject.
+		mlen = sizeof(recovered);
+		int ret3 = NaCl::crypto_sign_open(recovered, &mlen, sm, smlen, pk);
+
+		fail = (ret1 != 0) || (ret2 != 0) || (ret3 == 0);
+	}
+	catch (const Exception&) {
+		fail = true;
+	}
+
+	pass = pass && !fail;
+
+	std::cout << (fail ? "FAILED" : "passed") << "  ";
+	std::cout << "Ed25519 scalar canonicality, NaCl path (Issue 1352)" << std::endl;
+#endif
+
 	return pass;
 }
 


### PR DESCRIPTION
## Summary

This fixes two issues reported upstream.

- Upstream issue 1353: `DERReencode` recursed through nested indefinite ASN.1 without a depth limit. It now caps recursion depth so deeply nested indefinite BER fails cleanly instead of exhausting the stack.
- Upstream issue 1352: Ed25519 verification accepted non-canonical signatures with `S >= L`. Both the Donna verifier and the NaCl C API path now reject non-canonical `S` values.

The changes are intentionally small and limited to the affected parser and verifier paths, with validation coverage added alongside them.

## Details

### DERReencode recursion depth

`DERReencode` could recurse without limit when re-encoding nested constructed indefinite BER. A crafted input could keep adding `0x30 0x80` layers until the thread stack ran out.

The fix keeps the public `DERReencode` API as-is, but routes it through a depth-tracked helper. Inputs deeper than 32 levels now throw instead of recursing further. The limit matches OpenSSL's `ASN1_MAX_CONSTRUCTED_NEST`.

The main path of interest is PKCS#8 private key import through `BERDecodeOptionalAttributes`.

### Ed25519 S canonicality

The Ed25519 verifiers accepted signatures where `S >= L`.

That is a conformance issue, not a forgery, but it still matters when callers key behaviour on raw signature bytes, such as replay caches, audit trails, deduplication, allowlists, or interop with stricter implementations.

This patches both affected paths:

- the Donna verifier
- the NaCl C API verifier exposed through `naclite.h`

Both now reject non-canonical `S` before continuing with verification.

## References

- [Crypto++ issue 1353](https://github.com/weidai11/cryptopp/issues/1353)
- [Crypto++ issue 1352](https://github.com/weidai11/cryptopp/issues/1352)