### PR TITLE
Reject small-order Ed25519 public keys in Validate

### DIFF
--- a/src/pubkey/xed25519.cpp
+++ b/src/pubkey/xed25519.cpp
@@ -843,7 +843,11 @@ const Integer& ed25519PublicKey::GetPublicElement() const
 
 bool ed25519PublicKey::Validate(RandomNumberGenerator &rng, unsigned int level) const
 {
-    CRYPTOPP_UNUSED(rng); CRYPTOPP_UNUSED(level);
+    CRYPTOPP_UNUSED(rng);
+    CRYPTOPP_ASSERT(HasSmallOrder(m_pk) == false);
+
+    if (level >= 2 && HasSmallOrder(m_pk) == true)
+        return false;
     return IsCanonicalY(m_pk);
 }
 

--- a/src/test/validat7.cpp
+++ b/src/test/validat7.cpp
@@ -824,6 +824,30 @@ bool TestEd25519()
 	std::cout << "Ed25519 scalar canonicality, NaCl path (Issue 1352)" << std::endl;
 #endif
 
+	// Issue weidai11/cryptopp#1352. Validate at level 2 must reject small-order
+	// public keys. Identity is one of the 12 blacklisted points.
+	try {
+		byte identity[32] = { 0 };
+		identity[0] = 1;
+		ed25519Verifier verifier(identity);
+
+		bool basic = verifier.GetPublicKey().Validate(GlobalRNG(), 0);
+		bool strict = verifier.GetPublicKey().Validate(GlobalRNG(), 2);
+
+		ed25519Signer signer(GlobalRNG());
+		bool fresh = ed25519Verifier(signer).GetPublicKey().Validate(GlobalRNG(), 2);
+
+		fail = !basic || strict || !fresh;
+	}
+	catch (const Exception&) {
+		fail = true;
+	}
+
+	pass = pass && !fail;
+
+	std::cout << (fail ? "FAILED" : "passed") << "  ";
+	std::cout << "Ed25519 small-order public key (Issue 1352)" << std::endl;
+
 	return pass;
 }
 

--- a/src/test/validat9.cpp
+++ b/src/test/validat9.cpp
@@ -752,11 +752,13 @@ bool ValidateEd25519()
 		ed25519PublicKey k_pplus1; k_pplus1.SetPublicElement(pk_pplus1);
 		ed25519PublicKey k_top; k_top.SetPublicElement(pk_top);
 
-		const bool v_id = k_id.Validate(NullRNG(), 3);
-		const bool v_pminus1 = k_pminus1.Validate(NullRNG(), 3);
-		const bool v_p = k_p.Validate(NullRNG(), 3);
-		const bool v_pplus1 = k_pplus1.Validate(NullRNG(), 3);
-		const bool v_top = k_top.Validate(NullRNG(), 3);
+		// Level 1 exercises canonicality only; level 2+ adds small-order
+		// rejection which would also catch the canonical baselines below.
+		const bool v_id = k_id.Validate(NullRNG(), 1);
+		const bool v_pminus1 = k_pminus1.Validate(NullRNG(), 1);
+		const bool v_p = k_p.Validate(NullRNG(), 1);
+		const bool v_pplus1 = k_pplus1.Validate(NullRNG(), 1);
+		const bool v_top = k_top.Validate(NullRNG(), 1);
 
 		// R = identity, S = 0 verifies against the identity key and any of its aliases.
 		byte sig[64] = { 0 };


### PR DESCRIPTION
## Summary

This closes the remaining small-order public key part of upstream issue `weidai11/cryptopp#1352`.

`ed25519PublicKey::Validate` now rejects small-order Ed25519 public keys at validation level 2 and above. The existing canonical encoding check still runs at all validation levels, so level 0 behaviour is unchanged.

## What changed

- `ed25519PublicKey::Validate` now uses the existing `HasSmallOrder` helper at level 2 and above.
- `validat7.cpp` adds coverage for the level boundary: identity accepted at level 0, identity rejected at level 2, fresh keypair accepted at level 2.
- `validat9.cpp` now runs the non-canonical public-key test at level 1 so it stays scoped to canonicality.

This follows upstream commit `weidai11/cryptopp@4775a166`.