### PR TITLE
Fix MSVC MASM object paths under CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1272,21 +1272,22 @@ set_source_files_properties(
 # Compiler: MSVC
 # ------------------------------------------------------------------------------
 if(MSVC AND NOT CRYPTOPP_DISABLE_ASM)
-    if(${CMAKE_GENERATOR_PLATFORM} MATCHES "ARM" OR CRYPTOPP_ARM32 OR CRYPTOPP_ARMV8)
+    # Bare variable names so an unset CMAKE_GENERATOR_PLATFORM fails the match
+    # instead of expanding to an empty token. CMAKE_VS_PLATFORM_NAME backs it up.
+    if(
+        CMAKE_GENERATOR_PLATFORM MATCHES "ARM"
+        OR CMAKE_VS_PLATFORM_NAME MATCHES "ARM"
+        OR CRYPTOPP_ARM32
+        OR CRYPTOPP_ARMV8
+    )
         message(
             STATUS
-            "[cryptopp-modern] Disabling ASM because ARM is specified as target platform."
+            "[cryptopp-modern] Disabling ASM for ARM target."
         )
     else()
         enable_language(ASM_MASM)
         if(NOT CRYPTOPP_DISABLE_RDRAND)
             list(APPEND cryptopp_SOURCES_ASM ${cryptopp_SOURCE_DIR}/src/random/rdrand.asm)
-            if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
-                set_source_files_properties(
-                    ${cryptopp_SOURCE_DIR}/src/random/rdrand.asm
-                    PROPERTIES COMPILE_OPTIONS "/Fo\$(IntDir)rdrand.asm.obj"
-                )
-            endif()
         endif()
         if(NOT CRYPTOPP_DISABLE_RDSEED)
             list(APPEND cryptopp_SOURCES_ASM ${cryptopp_SOURCE_DIR}/src/random/rdseed.asm)
@@ -1319,6 +1320,15 @@ if(MSVC AND NOT CRYPTOPP_DISABLE_ASM)
             ${cryptopp_SOURCES_ASM}
             PROPERTIES LANGUAGE ASM_MASM
         )
+        # The Visual Studio generator can place MASM objects under source-tree
+        # subdirs (src/random) that ml64 may not create, failing with A1000.
+        # Keep them flat under $(IntDir) via ObjectFileName metadata.
+        if(CMAKE_GENERATOR MATCHES "Visual Studio")
+            set_source_files_properties(
+                ${cryptopp_SOURCES_ASM}
+                PROPERTIES VS_SETTINGS "ObjectFileName=\$(IntDir)%(Filename).asm.obj"
+            )
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ project(
     VERSION "${META_VERSION}"
     DESCRIPTION "${META_PROJECT_DESCRIPTION}"
     HOMEPAGE_URL "${META_GITHUB_REPO}"
-    LANGUAGES CXX C ASM
+    LANGUAGES CXX C
 )
 
 message(STATUS "=> Project : ${PROJECT_NAME} v${cryptopp-modern_VERSION}")
@@ -1267,6 +1267,11 @@ set_source_files_properties(
     ${cryptopp_SOURCE_DIR}/src/core/sse_simd.cpp
     PROPERTIES COMPILE_OPTIONS "${CRYPTOPP_SSE2_FLAGS}"
 )
+
+# CryptoGAMS ARM sources use GNU assembler syntax.
+if((CRYPTOPP_ARM32 OR CRYPTOPP_ARMV8) AND NOT MSVC AND NOT CRYPTOPP_DISABLE_ASM)
+    enable_language(ASM)
+endif()
 
 # ------------------------------------------------------------------------------
 # Compiler: MSVC


### PR DESCRIPTION
## Summary

Fixes #43. MASM can fail under the Visual Studio generator when `ml64` is given a `/Fo` path under a source-tree subdirectory such as `src/random`.

`-DCRYPTOPP_DISABLE_ASM=ON` remains the workaround for affected builds.

## What changed

- Write all MASM objects flat under `$(IntDir)` using `ObjectFileName`.
- Remove the old `rdrand.asm`-only `/Fo` override.
- Tighten the ARM target check so ARM builds skip the MASM path.

VS 2026 could not be reproduced locally, so the reporter will confirm that toolchain. CI covers the existing VS 2022 ASM path.

Closes #43