### PR TITLE
Switch pkgconfig and cmake files to cmake libdir

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -183,7 +183,7 @@ jobs:
         test -f build/install/lib/libcryptopp.a
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
-        test -f build/install/share/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
         ls -la build/install/include/cryptopp/ | head -20
 
     - name: Test find_package integration

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -190,7 +190,7 @@ jobs:
         test -f build/install/lib/libcryptopp.a
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
-        test -f build/install/share/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
         ls -la build/install/include/cryptopp/ | head -20
 
     - name: Test find_package integration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1563,7 +1563,7 @@ if(CRYPTOPP_INSTALL)
 
     install(
         EXPORT ${TARGETS_EXPORT_NAME}
-        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/cmake/cryptopp-modern"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cryptopp-modern"
         NAMESPACE cryptopp::
         FILE cryptopp-modern-${type}-targets.cmake
         COMPONENT ${dev}
@@ -1574,12 +1574,12 @@ if(CRYPTOPP_INSTALL)
         FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cryptopp-modernConfig.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modernConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/cryptopp-modern
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cryptopp-modern
         COMPONENT ${dev}
     )
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modern.pc
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
         COMPONENT ${dev}
     )
 


### PR DESCRIPTION
As cryptopp is a binary library, theses files should be distributed under a binary specific directory.


Side note:  any reason to break compatibility with pkgconfig ? previous files where libcryptopp.pc and was renamed to cryptopp-modern.pc breaking compatibility ? (so it requires to change all underlying application in order to support pkgconfig for no reason).

