### PR TITLE
Restore libcryptopp.pc for pkg-config compatibility

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -184,6 +184,22 @@ jobs:
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
         test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        # Both pkg-config names must resolve and yield usable flags; the
+        # cryptopp-modern alias forwards to libcryptopp through Requires.
+        export PKG_CONFIG_PATH="$PWD/build/install/lib/pkgconfig"
+        pkg-config --exists libcryptopp
+        pkg-config --exists cryptopp-modern
+        pkg-config --cflags --libs libcryptopp
+        pkg-config --cflags --libs cryptopp-modern
+        test "$(pkg-config --libs cryptopp-modern)" = "$(pkg-config --libs libcryptopp)"
+        # A mismatched libcryptopp.pc earlier in the path must not satisfy the
+        # version-pinned alias; the lookup should fail rather than resolve to it.
+        mkdir -p "$RUNNER_TEMP/fakepc"
+        printf 'Name: libcryptopp\nDescription: mismatched\nVersion: 0.0.0\nCflags: -I/nonexistent\n' > "$RUNNER_TEMP/fakepc/libcryptopp.pc"
+        if PKG_CONFIG_PATH="$RUNNER_TEMP/fakepc:$PWD/build/install/lib/pkgconfig" pkg-config --exists cryptopp-modern; then
+          echo "ERROR: alias resolved through a mismatched libcryptopp.pc" >&2
+          exit 1
+        fi
         ls -la build/install/include/cryptopp/ | head -20
 
     - name: Test find_package integration

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,6 +191,22 @@ jobs:
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
         test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        # Both pkg-config names must resolve and yield usable flags; the
+        # cryptopp-modern alias forwards to libcryptopp through Requires.
+        export PKG_CONFIG_PATH="$PWD/build/install/lib/pkgconfig"
+        pkg-config --exists libcryptopp
+        pkg-config --exists cryptopp-modern
+        pkg-config --cflags --libs libcryptopp
+        pkg-config --cflags --libs cryptopp-modern
+        test "$(pkg-config --libs cryptopp-modern)" = "$(pkg-config --libs libcryptopp)"
+        # A mismatched libcryptopp.pc earlier in the path must not satisfy the
+        # version-pinned alias; the lookup should fail rather than resolve to it.
+        mkdir -p "$RUNNER_TEMP/fakepc"
+        printf 'Name: libcryptopp\nDescription: mismatched\nVersion: 0.0.0\nCflags: -I/nonexistent\n' > "$RUNNER_TEMP/fakepc/libcryptopp.pc"
+        if PKG_CONFIG_PATH="$RUNNER_TEMP/fakepc:$PWD/build/install/lib/pkgconfig" pkg-config --exists cryptopp-modern; then
+          echo "ERROR: alias resolved through a mismatched libcryptopp.pc" >&2
+          exit 1
+        fi
         ls -la build/install/include/cryptopp/ | head -20
 
     - name: Test find_package integration

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -198,8 +198,8 @@ cmake --install build
 |-----------|----------|
 | `include/cryptopp/` | All header files |
 | `lib/` | Static library (`libcryptopp.a` or `cryptopp.lib`) |
-| `lib/pkgconfig/` | pkg-config file (`cryptopp.pc`) |
-| `share/cmake/cryptopp-modern/` | CMake config files for `find_package()` |
+| `lib/pkgconfig/` | pkg-config files (`libcryptopp.pc` and the `cryptopp-modern.pc` alias) |
+| `lib/cmake/cryptopp-modern/` | CMake config files for `find_package()` |
 | `share/cryptopp/` | TestData and TestVectors |
 | `bin/` | Test executable (`cryptest.exe`) |
 
@@ -296,6 +296,7 @@ cryptopp-modern/
 │   ├── cmake_minimum_required.cmake
 │   ├── ConfigFiles.cmake    # Package config generation
 │   ├── config.pc.in         # pkg-config template
+│   ├── config-alias.pc.in   # pkg-config compatibility alias
 │   ├── cryptopp-modernConfig.cmake  # find_package() config
 │   ├── GetGitRevisionDescription.cmake
 │   ├── GetGitRevisionDescription.cmake.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1578,7 +1578,9 @@ if(CRYPTOPP_INSTALL)
         COMPONENT ${dev}
     )
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modern.pc
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc
+            ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modern.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
         COMPONENT ${dev}
     )

--- a/cmake/ConfigFiles.cmake
+++ b/cmake/ConfigFiles.cmake
@@ -19,7 +19,6 @@ endfunction()
 
 function(_module_pkgconfig_files)
     message(STATUS "[cryptopp-modern] Generating pkgconfig files")
-    set(MODULE_PKGCONFIG_FILE cryptopp-modern.pc)
 
     if(CMAKE_BUILD_TYPE EQUAL "Debug")
         get_target_property(target_debug_postfix cryptopp DEBUG_POSTFIX)
@@ -29,9 +28,19 @@ function(_module_pkgconfig_files)
     endif()
     set(MODULE_LINK_LIBS "-lcryptopp${target_debug_postfix}")
 
+    # Primary file is named libcryptopp.pc to match upstream Crypto++, so
+    # `pkg-config libcryptopp` keeps working for existing consumers.
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.pc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/${MODULE_PKGCONFIG_FILE}
+        ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc
+        @ONLY
+    )
+
+    # Alias for consumers that adopted the fork's cryptopp-modern name; it
+    # forwards to libcryptopp rather than repeating the flags.
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config-alias.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modern.pc
         @ONLY
     )
 endfunction()

--- a/cmake/config-alias.pc.in
+++ b/cmake/config-alias.pc.in
@@ -1,0 +1,7 @@
+# cryptopp-modern pkg-config compatibility alias for libcryptopp
+
+Name: cryptopp-modern
+URL: https://github.com/cryptopp-modern/cryptopp-modern
+Description: Compatibility alias for libcryptopp
+Version: @cryptopp-modern_VERSION@
+Requires: libcryptopp = @cryptopp-modern_VERSION@


### PR DESCRIPTION
Restore `libcryptopp.pc` for upstream pkg-config compatibility and keep `cryptopp-modern.pc` as a version pinned alias.
Update the install docs and add regression checks for both package names.

Closes #47.