### PR TITLE
Fix ARM64 Windows build and add CI coverage

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -137,6 +137,28 @@ jobs:
     - name: Run test vectors
       run: ./build/ci-windows/Release/cryptest.exe tv all
 
+  cmake-windows-arm64:
+    # ARM64 Windows host with the Visual Studio generator, covering issue #43:
+    # MASM (ml64) A1000 when the generator writes ASM objects under a source
+    # subdir. Builds for x64 (MASM active) and ARM64 (ASM disabled). Runners
+    # ship Visual Studio 2022; the reporter hit it on 2026, so a pass here
+    # covers the ARM64 host path but not the 2026-specific toolset.
+    name: CMake Windows ARM64 host (MSVC, ${{ matrix.target }})
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x64, ARM64]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Configure (Visual Studio generator, ${{ matrix.target }} target)
+      run: cmake -S . -B build/ci-win-arm -G "Visual Studio 17 2022" -A ${{ matrix.target }} -DCMAKE_BUILD_TYPE=Release -DCRYPTOPP_BUILD_TESTING=ON
+
+    - name: Build
+      run: cmake --build build/ci-win-arm --config Release
+
   cmake-no-asm:
     name: CMake No-ASM (Pure C++)
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -144,6 +144,28 @@ jobs:
     - name: Run test vectors
       run: ./build/ci-windows/Release/cryptest.exe tv all
 
+  cmake-windows-arm64:
+    # ARM64 Windows host with the Visual Studio generator, covering issue #43:
+    # MASM (ml64) A1000 when the generator writes ASM objects under a source
+    # subdir. Builds for x64 (MASM active) and ARM64 (ASM disabled). Runners
+    # ship Visual Studio 2022; the reporter hit it on 2026, so a pass here
+    # covers the ARM64 host path but not the 2026-specific toolset.
+    name: CMake Windows ARM64 host (MSVC, ${{ matrix.target }})
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x64, ARM64]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Configure (Visual Studio generator, ${{ matrix.target }} target)
+      run: cmake -S . -B build/ci-win-arm -G "Visual Studio 17 2022" -A ${{ matrix.target }} -DCMAKE_BUILD_TYPE=Release -DCRYPTOPP_BUILD_TESTING=ON
+
+    - name: Build
+      run: cmake --build build/ci-win-arm --config Release
+
   cmake-no-asm:
     name: CMake No-ASM (Pure C++)
     runs-on: ubuntu-24.04

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -19,6 +19,16 @@
 #include <cstdio>
 #include <limits>
 
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
+# include <windows.h>
+#endif
+
 // Aggressive stack checking with VS2005 SP1 and above.
 #if (_MSC_FULL_VER >= 140050727)
 # pragma strict_gs_check (on)
@@ -3178,11 +3188,6 @@ bool ValidateHSS()
 // Mirror FileStateStore path handling for non-ASCII test paths.
 
 #ifdef _WIN32
-# ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# include <windows.h>
-
 static std::wstring TestUtf8PathToWide(const std::string &path)
 {
 	if (path.empty()) return std::wstring();


### PR DESCRIPTION
Fixes the ARM64 Windows cryptest build and adds `windows-11-arm` CI coverage.

- Move the `<windows.h>` include in `validat12.cpp` out of `CryptoPP::Test`.
- Add x64 and ARM64 Visual Studio builds on `windows-11-arm`. The x64 job covers the MASM path from issue ([#43](https://github.com/cryptopp-modern/cryptopp-modern/issues/43)); ARM64 uses the pure C++ path.

## Verification

Both configurations pass in a private workflow run.