### PR TITLE
Feature/shared library

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -254,6 +254,131 @@ jobs:
         cmake --build build
         ./build/test-app
 
+  cmake-shared:
+    name: CMake Shared Library Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (shared, tests on)
+      run: >
+        cmake -S . -B build/shared -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCRYPTOPP_BUILD_SHARED=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/shared-install
+
+    - name: Build
+      run: cmake --build build/shared -j"$(nproc)"
+
+    - name: Validate against the shared library
+      run: |
+        # cryptest links the .so, so a passing run proves the API is exported,
+        # and cryptest itself must record a NEEDED entry for the ABI SONAME.
+        cd build/shared
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+        readelf -d ./cryptest.exe | grep -qE 'NEEDED.*libcryptopp\.so\.[0-9]+\]' \
+          || { echo "ERROR: cryptest is not linked against the shared library"; exit 1; }
+
+    - name: Install
+      run: cmake --install build/shared
+
+    - name: Verify SONAME, symlink chain and downstream consumers
+      run: |
+        INST="${{ github.workspace }}/build/shared-install"
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        REAL=$(find "$INST" -name 'libcryptopp.so.*' -type f | head -1)
+        LIBDIR=$(dirname "$REAL")
+        PCDIR=$(dirname "$(find "$INST" -name libcryptopp.pc | head -1)")
+        SONAME=$(readelf -d "$REAL" | grep -oE 'libcryptopp\.so\.[0-9.]+' | head -1)
+        echo "SONAME=$SONAME  file=$(basename "$REAL")  ABI=$ABI"
+        # SONAME must be exactly the ABI version, not the release version.
+        test "$SONAME" = "libcryptopp.so.$ABI" \
+          || { echo "ERROR: SONAME $SONAME != libcryptopp.so.$ABI"; exit 1; }
+        # Symlink chain: libcryptopp.so -> libcryptopp.so.$ABI -> real file.
+        test "$(readlink "$LIBDIR/libcryptopp.so")" = "$SONAME"
+        test "$(readlink "$LIBDIR/$SONAME")" = "$(basename "$REAL")"
+        # The consumer calls an out-of-line longstanding symbol (SHA256) and an
+        # out-of-line fork-added symbol (BLAKE3); a header-only call would not
+        # prove the symbols are exported. Built at the project C++11 baseline.
+        cat > consumer.cpp << 'EOF'
+        #include <cryptopp/sha.h>
+        #include <cryptopp/blake3.h>
+        #include <cryptopp/cryptlib.h>
+        #include <vector>
+        using namespace CryptoPP;
+        int main() {
+            const byte msg[3] = {'a','b','c'};
+            SHA256 sha; std::vector<byte> d1(sha.DigestSize());
+            sha.CalculateDigest(d1.data(), msg, 3);
+            BLAKE3 b3; std::vector<byte> d2(b3.DigestSize());
+            b3.CalculateDigest(d2.data(), msg, 3);
+            return (d1[0] == 0xba && d2[0] == 0x64) ? 0 : 1;  // digests of "abc"
+        }
+        EOF
+        # Consumer A: pkg-config libcryptopp
+        g++ -std=c++11 consumer.cpp \
+          $(PKG_CONFIG_PATH="$PCDIR" pkg-config --cflags --libs libcryptopp) -o consumer_pc
+        readelf -d consumer_pc | grep -qE "NEEDED.*$SONAME" \
+          || { echo "ERROR: pkg-config consumer is not linked against $SONAME"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./consumer_pc
+        # Consumer B: find_package(cryptopp-modern)
+        mkdir -p fp && cp consumer.cpp fp/ && cd fp
+        cat > CMakeLists.txt << 'EOF'
+        cmake_minimum_required(VERSION 3.20)
+        project(consumer CXX)
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+        find_package(cryptopp-modern REQUIRED)
+        add_executable(consumer_fp consumer.cpp)
+        target_link_libraries(consumer_fp PRIVATE cryptopp::cryptopp)
+        EOF
+        cmake -S . -B b -DCMAKE_PREFIX_PATH="$INST" > /dev/null
+        cmake --build b > /dev/null
+        readelf -d b/consumer_fp | grep -qE "NEEDED.*$SONAME" \
+          || { echo "ERROR: find_package consumer is not linked against $SONAME"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./b/consumer_fp
+        echo "shared library consumers OK ($SONAME)"
+
+    - name: GNUmakefile shared build SONAME parity
+      run: |
+        # The GNUmakefile is the other build system; its SONAME must match the
+        # CMake one, since both derive from CRYPTOPP_ABI_VERSION.
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        make -j"$(nproc)" shared
+        MK_REAL=$(find . -maxdepth 1 -name 'libcryptopp.so.*' -type f | head -1)
+        MK_SONAME=$(readelf -d "$MK_REAL" | grep -oE 'libcryptopp\.so\.[0-9.]+' | head -1)
+        echo "GNUmakefile SONAME=$MK_SONAME (file $(basename "$MK_REAL"))  ABI=$ABI"
+        test "$MK_SONAME" = "libcryptopp.so.$ABI" \
+          || { echo "ERROR: GNUmakefile SONAME $MK_SONAME != libcryptopp.so.$ABI"; exit 1; }
+
+  makefile-macos-dylib:
+    name: Makefile macOS dylib
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: make dylib and check versions
+      run: |
+        # compatibility_version must be the ABI version; current_version keeps
+        # the release version. macOS pads a bare version to X.Y.Z.
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        make -j"$(sysctl -n hw.ncpu)" dylib
+        otool -l libcryptopp.dylib | grep -A5 LC_ID_DYLIB
+        COMPAT=$(otool -l libcryptopp.dylib | awk '/LC_ID_DYLIB/{f=1} f&&/compatibility version/{print $3; exit}')
+        CURRENT=$(otool -l libcryptopp.dylib | awk '/LC_ID_DYLIB/{f=1} f&&/current version/{print $3; exit}')
+        echo "compatibility_version=$COMPAT  current_version=$CURRENT  ABI=$ABI"
+        case "$COMPAT" in
+          "$ABI"|"$ABI.0"|"$ABI.0.0") echo "compatibility_version matches ABI" ;;
+          *) echo "ERROR: compatibility_version $COMPAT != ABI $ABI"; exit 1 ;;
+        esac
+
   # =============================================================================
   # Makefile Builds (Backward Compatibility)
   # =============================================================================

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -261,6 +261,131 @@ jobs:
         cmake --build build
         ./build/test-app
 
+  cmake-shared:
+    name: CMake Shared Library Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (shared, tests on)
+      run: >
+        cmake -S . -B build/shared -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCRYPTOPP_BUILD_SHARED=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/shared-install
+
+    - name: Build
+      run: cmake --build build/shared -j"$(nproc)"
+
+    - name: Validate against the shared library
+      run: |
+        # cryptest links the .so, so a passing run proves the API is exported,
+        # and cryptest itself must record a NEEDED entry for the ABI SONAME.
+        cd build/shared
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+        readelf -d ./cryptest.exe | grep -qE 'NEEDED.*libcryptopp\.so\.[0-9]+\]' \
+          || { echo "ERROR: cryptest is not linked against the shared library"; exit 1; }
+
+    - name: Install
+      run: cmake --install build/shared
+
+    - name: Verify SONAME, symlink chain and downstream consumers
+      run: |
+        INST="${{ github.workspace }}/build/shared-install"
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        REAL=$(find "$INST" -name 'libcryptopp.so.*' -type f | head -1)
+        LIBDIR=$(dirname "$REAL")
+        PCDIR=$(dirname "$(find "$INST" -name libcryptopp.pc | head -1)")
+        SONAME=$(readelf -d "$REAL" | grep -oE 'libcryptopp\.so\.[0-9.]+' | head -1)
+        echo "SONAME=$SONAME  file=$(basename "$REAL")  ABI=$ABI"
+        # SONAME must be exactly the ABI version, not the release version.
+        test "$SONAME" = "libcryptopp.so.$ABI" \
+          || { echo "ERROR: SONAME $SONAME != libcryptopp.so.$ABI"; exit 1; }
+        # Symlink chain: libcryptopp.so -> libcryptopp.so.$ABI -> real file.
+        test "$(readlink "$LIBDIR/libcryptopp.so")" = "$SONAME"
+        test "$(readlink "$LIBDIR/$SONAME")" = "$(basename "$REAL")"
+        # The consumer calls an out-of-line longstanding symbol (SHA256) and an
+        # out-of-line fork-added symbol (BLAKE3); a header-only call would not
+        # prove the symbols are exported. Built at the project C++11 baseline.
+        cat > consumer.cpp << 'EOF'
+        #include <cryptopp/sha.h>
+        #include <cryptopp/blake3.h>
+        #include <cryptopp/cryptlib.h>
+        #include <vector>
+        using namespace CryptoPP;
+        int main() {
+            const byte msg[3] = {'a','b','c'};
+            SHA256 sha; std::vector<byte> d1(sha.DigestSize());
+            sha.CalculateDigest(d1.data(), msg, 3);
+            BLAKE3 b3; std::vector<byte> d2(b3.DigestSize());
+            b3.CalculateDigest(d2.data(), msg, 3);
+            return (d1[0] == 0xba && d2[0] == 0x64) ? 0 : 1;  // digests of "abc"
+        }
+        EOF
+        # Consumer A: pkg-config libcryptopp
+        g++ -std=c++11 consumer.cpp \
+          $(PKG_CONFIG_PATH="$PCDIR" pkg-config --cflags --libs libcryptopp) -o consumer_pc
+        readelf -d consumer_pc | grep -qE "NEEDED.*$SONAME" \
+          || { echo "ERROR: pkg-config consumer is not linked against $SONAME"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./consumer_pc
+        # Consumer B: find_package(cryptopp-modern)
+        mkdir -p fp && cp consumer.cpp fp/ && cd fp
+        cat > CMakeLists.txt << 'EOF'
+        cmake_minimum_required(VERSION 3.20)
+        project(consumer CXX)
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+        find_package(cryptopp-modern REQUIRED)
+        add_executable(consumer_fp consumer.cpp)
+        target_link_libraries(consumer_fp PRIVATE cryptopp::cryptopp)
+        EOF
+        cmake -S . -B b -DCMAKE_PREFIX_PATH="$INST" > /dev/null
+        cmake --build b > /dev/null
+        readelf -d b/consumer_fp | grep -qE "NEEDED.*$SONAME" \
+          || { echo "ERROR: find_package consumer is not linked against $SONAME"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./b/consumer_fp
+        echo "shared library consumers OK ($SONAME)"
+
+    - name: GNUmakefile shared build SONAME parity
+      run: |
+        # The GNUmakefile is the other build system; its SONAME must match the
+        # CMake one, since both derive from CRYPTOPP_ABI_VERSION.
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        make -j"$(nproc)" shared
+        MK_REAL=$(find . -maxdepth 1 -name 'libcryptopp.so.*' -type f | head -1)
+        MK_SONAME=$(readelf -d "$MK_REAL" | grep -oE 'libcryptopp\.so\.[0-9.]+' | head -1)
+        echo "GNUmakefile SONAME=$MK_SONAME (file $(basename "$MK_REAL"))  ABI=$ABI"
+        test "$MK_SONAME" = "libcryptopp.so.$ABI" \
+          || { echo "ERROR: GNUmakefile SONAME $MK_SONAME != libcryptopp.so.$ABI"; exit 1; }
+
+  makefile-macos-dylib:
+    name: Makefile macOS dylib
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: make dylib and check versions
+      run: |
+        # compatibility_version must be the ABI version; current_version keeps
+        # the release version. macOS pads a bare version to X.Y.Z.
+        ABI=$(grep -oE 'define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+' include/cryptopp/config_ver.h | grep -oE '[0-9]+$')
+        make -j"$(sysctl -n hw.ncpu)" dylib
+        otool -l libcryptopp.dylib | grep -A5 LC_ID_DYLIB
+        COMPAT=$(otool -l libcryptopp.dylib | awk '/LC_ID_DYLIB/{f=1} f&&/compatibility version/{print $3; exit}')
+        CURRENT=$(otool -l libcryptopp.dylib | awk '/LC_ID_DYLIB/{f=1} f&&/current version/{print $3; exit}')
+        echo "compatibility_version=$COMPAT  current_version=$CURRENT  ABI=$ABI"
+        case "$COMPAT" in
+          "$ABI"|"$ABI.0"|"$ABI.0.0") echo "compatibility_version matches ABI" ;;
+          *) echo "ERROR: compatibility_version $COMPAT != ABI $ABI"; exit 1 ;;
+        esac
+
   # =============================================================================
   # CMake Android Cross-compile (build-only, no emulator)
   # =============================================================================

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -93,7 +93,7 @@ cmake --build --preset=debug
 |--------|---------|-------------|
 | `CRYPTOPP_BUILD_TESTING` | `ON` | Build the test executable (cryptest.exe) |
 | `CRYPTOPP_INSTALL` | `ON` | Generate install targets |
-| `CRYPTOPP_BUILD_SHARED` | `OFF` | Build shared library (NOT supported - Crypto++ doesn't properly support DLLs) |
+| `CRYPTOPP_BUILD_SHARED` | `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
 | `CRYPTOPP_USE_OPENMP` | `OFF` | Enable OpenMP for parallel algorithms |
 | `CRYPTOPP_INCLUDE_PREFIX` | `cryptopp` | Header installation directory name |
 
@@ -140,6 +140,33 @@ cmake -B build -DCRYPTOPP_BUILD_TESTING=OFF
 # Build with OpenMP
 cmake -B build -DCRYPTOPP_USE_OPENMP=ON
 ```
+
+## Shared Library (Unix)
+
+On Linux, macOS and other Unix-like platforms the library can be built shared:
+
+```bash
+cmake -B build -DCRYPTOPP_BUILD_SHARED=ON
+cmake --build build
+```
+
+Windows remains static-only; requesting a shared build there fails at configure time. The old Windows DLL was the FIPS module, which is abandoned, and its hand-maintained export set is gone.
+
+Unix shared builds compile with default symbol visibility, so the full API is exported. When tests are enabled, cryptest links against the shared library and the validation suite runs against it.
+
+### SONAME and ABI version
+
+The SONAME carries an ABI version that is independent of the calendar release version. It comes from the `CRYPTOPP_ABI_VERSION` macro in `include/cryptopp/config_ver.h`, is read by both the CMake and GNUmakefile builds, and increments only for ABI-incompatible changes. On Linux the installed files look like:
+
+```
+libcryptopp.so            -> libcryptopp.so.1
+libcryptopp.so.1          -> libcryptopp.so.2026.7.1    (SONAME)
+libcryptopp.so.2026.7.1                                 (real file)
+```
+
+On macOS the ABI version sets the dylib `compatibility_version` and the release version sets `current_version`.
+
+The ABI series is independent of upstream Crypto++'s (`libcryptopp.so.8`). The two runtime libraries can be installed side by side, and a binary linked against one never binds to the other.
 
 ## Using cryptopp-modern in Your CMake Project
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,17 +115,16 @@ option(CRYPTOPP_BUILD_TESTING "Build library tests" ON)
 # install/no-install behavior for cryptopp module.
 option(CRYPTOPP_INSTALL "Generate the install target for this project." ON)
 
-# Crypto++ DOES NOT properly support DLL builds. The old DLL was the FIPS one,
-# which is being abandoned. Therefore, we only allow static builds.
+# Windows DLL builds are not supported. The old DLL was the FIPS one, which is
+# abandoned, and its hand-maintained export set is gone. Shared builds are
+# allowed on Unix-like platforms, where the library exports the full API.
 option(CRYPTOPP_BUILD_SHARED "Build shared library" OFF)
-if(${CRYPTOPP_BUILD_SHARED})
+if(CRYPTOPP_BUILD_SHARED AND WIN32)
     message(
         FATAL_ERROR
-        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-        "Crypto++ DOES NOT properly support DLL builds. The old DLL was the FIPS "
-        "one which is being abandoned.\nTherefore, we only allow static builds "
-        "until that situation changes.\n"
-        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+        "Shared (DLL) builds are not supported on Windows. The old DLL was the "
+        "FIPS one, which is abandoned. Build a static library on Windows, or "
+        "build shared on a non-Windows target."
     )
 endif()
 
@@ -1381,20 +1380,50 @@ if(
     set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 endif()
 
+# Shared library ABI version, read from config_ver.h so the CMake and
+# GNUmakefile builds share one source. It is independent of the release
+# version. Fail closed if it is missing, duplicated, or not a positive integer.
+file(STRINGS
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/cryptopp/config_ver.h"
+    _cryptopp_abi_lines
+    REGEX "define[ ]+CRYPTOPP_ABI_VERSION[ ]+[0-9]+[ ]*$"
+)
+list(LENGTH _cryptopp_abi_lines _cryptopp_abi_count)
+if(NOT _cryptopp_abi_count EQUAL 1)
+    message(FATAL_ERROR
+        "CRYPTOPP_ABI_VERSION must be defined exactly once in config_ver.h")
+endif()
+string(REGEX MATCH "[0-9]+" CRYPTOPP_ABI_VERSION "${_cryptopp_abi_lines}")
+if(NOT CRYPTOPP_ABI_VERSION MATCHES "^[1-9][0-9]*$")
+    message(FATAL_ERROR
+        "CRYPTOPP_ABI_VERSION in config_ver.h must be a positive integer")
+endif()
+
 set(cryptopp_LIBRARY_SOURCES ${cryptopp_SOURCES_ASM})
 list(APPEND cryptopp_LIBRARY_SOURCES ${cryptopp_SOURCES})
 
 add_library(cryptopp ${cryptopp_LIBRARY_SOURCES})
 add_library(cryptopp::cryptopp ALIAS cryptopp)
+# VERSION is the release version (full filename, macOS current_version).
+# SOVERSION is the ABI version (SONAME, macOS compatibility_version).
 set_target_properties(
     cryptopp
     PROPERTIES
         VERSION ${cryptopp-modern_VERSION}
-        SOVERSION ${cryptopp-modern_VERSION_MAJOR}
+        SOVERSION ${CRYPTOPP_ABI_VERSION}
 )
 set_target_properties(cryptopp PROPERTIES LINKER_LANGUAGE CXX)
-if(${CRYPTOPP_BUILD_SHARED})
-    target_compile_definitions(cryptopp PRIVATE "CRYPTOPP_EXPORTS")
+# CRYPTOPP_EXPORTS belongs to the legacy Windows DLL machinery and is
+# deliberately not defined for Unix shared builds, which export through
+# default visibility.
+if(CRYPTOPP_BUILD_SHARED AND NOT WIN32)
+    # Export the full API from the shared library. Crypto++ does not annotate
+    # public symbols for GCC/Clang, so the project-wide hidden default would
+    # otherwise produce a .so that exports almost nothing.
+    set_target_properties(cryptopp PROPERTIES
+        CXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN OFF
+    )
 endif()
 target_compile_definitions(
     cryptopp

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1180,9 +1180,18 @@ ifeq ($(strip $(LIB_PATCH)),)
   LIB_PATCH := 0
 endif
 
+# Shared library ABI version. Read from the same header so this makefile and
+# CMake agree. Independent of the release version: the SONAME uses it, while the
+# full library filename keeps the release version.
+LIB_ABI_VERSION := $(shell $(GREP) "define CRYPTOPP_ABI_VERSION" include/cryptopp/config_ver.h | cut -d" " -f 3)
+LIB_ABI_VALID := $(shell echo "$(LIB_ABI_VERSION)" | $(GREP) -E '^[1-9][0-9]*$$')
+ifeq ($(strip $(LIB_ABI_VALID)),)
+  $(error CRYPTOPP_ABI_VERSION in include/cryptopp/config_ver.h must be a positive integer, got '$(LIB_ABI_VERSION)')
+endif
+
 ifeq ($(HAS_SOLIB_VERSION),1)
-# Different patchlevels and minors are compatible since 6.1
-SOLIB_COMPAT_SUFFIX=.$(LIB_MAJOR)
+# The SONAME carries the ABI version, not the release version.
+SOLIB_COMPAT_SUFFIX=.$(LIB_ABI_VERSION)
 # Linux uses -Wl,-soname
 ifneq ($(IS_LINUX)$(IS_HURD),00)
 # Linux uses full version suffix for shared library
@@ -1556,7 +1565,7 @@ ifeq ($(HAS_SOLIB_VERSION),1)
 endif
 
 libcryptopp.dylib: $(LIBOBJS) | osx_warning
-	$(CXX) -dynamiclib -o $@ $(CXXFLAGS) -install_name "$@" -current_version "$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)" -compatibility_version "$(LIB_MAJOR).$(LIB_MINOR)" -headerpad_max_install_names $(LDFLAGS) $(LIBOBJS)
+	$(CXX) -dynamiclib -o $@ $(CXXFLAGS) -install_name "$@" -current_version "$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)" -compatibility_version "$(LIB_ABI_VERSION)" -headerpad_max_install_names $(LDFLAGS) $(LIBOBJS)
 
 cryptest.exe: $(LINK_LIBRARY) $(TESTOBJS) | osx_warning
 	$(CXX) -o $@ $(CXXFLAGS) $(TESTOBJS) $(LINK_LIBRARY_PATH)$(LINK_LIBRARY) $(LDFLAGS) $(LDLIBS)

--- a/include/cryptopp/config_ver.h
+++ b/include/cryptopp/config_ver.h
@@ -59,6 +59,13 @@
 /// \since Crypto++ 5.6
 #define CRYPTOPP_VERSION 20260701
 
+/// \brief Shared library ABI version
+/// \details CRYPTOPP_ABI_VERSION is the shared library SONAME and the macOS
+///  compatibility version. It is independent of CRYPTOPP_VERSION and the
+///  calendar release cycle, and increments only for ABI-incompatible
+///  changes. The CMake and GNUmakefile builds both read this value.
+#define CRYPTOPP_ABI_VERSION 1
+
 // Compiler version macros
 
 // Apple and LLVM Clang versions. Apple Clang version 7.0 roughly equals


### PR DESCRIPTION
## Enable Unix shared library builds
Enable shared library builds on Unix-like platforms while keeping Windows static-only.

Add `CRYPTOPP_ABI_VERSION`, starting at 1, so the SONAME is independent of both the calendar release version and upstream’s `libcryptopp.so.8`.

Fixes #48.

## What changed
- Scope the CMake shared-build restriction to Windows.
- Build Unix shared targets with default visibility and link `cryptest` against the shared library.
- Use `CRYPTOPP_ABI_VERSION` for the CMake and GNUmakefile SONAME and macOS `compatibility_version`.
- Fail early if the ABI version macro is missing or malformed.
- Add Linux CI coverage for the shared build, `cryptest`, SONAME and symlink checks, and installed `pkg-config` and `find_package` consumers.
- Add macOS CI coverage for the dylib `compatibility_version`.
- Document shared builds in `CMAKE.md`.