### PR TITLE
Validate BLAKE3 inputs at runtime

### DIFF
--- a/include/cryptopp/blake3.h
+++ b/include/cryptopp/blake3.h
@@ -20,9 +20,9 @@ NAMESPACE_BEGIN(CryptoPP)
 
 /// \brief BLAKE3 hash information
 /// \since Crypto++ 8.9
-struct BLAKE3_Info : public VariableKeyLength<32,0,32,1,SimpleKeyingInterface::NOT_RESYNCHRONIZABLE>
+struct BLAKE3_Info : public FixedKeyLength<32,SimpleKeyingInterface::NOT_RESYNCHRONIZABLE>
 {
-	typedef VariableKeyLength<32,0,32,1,SimpleKeyingInterface::NOT_RESYNCHRONIZABLE> KeyBase;
+	typedef FixedKeyLength<32,SimpleKeyingInterface::NOT_RESYNCHRONIZABLE> KeyBase;
 	CRYPTOPP_CONSTANT(MIN_KEYLENGTH = KeyBase::MIN_KEYLENGTH);
 	CRYPTOPP_CONSTANT(MAX_KEYLENGTH = KeyBase::MAX_KEYLENGTH);
 	CRYPTOPP_CONSTANT(DEFAULT_KEYLENGTH = KeyBase::DEFAULT_KEYLENGTH);
@@ -125,19 +125,23 @@ public:
 
 	/// \brief Construct a BLAKE3 hash
 	/// \param digestSize the digest size, in bytes (default 32)
+	/// \throw InvalidArgument if digestSize is 0 or larger than 1024
 	/// \since Crypto++ 8.9
 	BLAKE3(unsigned int digestSize = DIGESTSIZE);
 
 	/// \brief Construct a BLAKE3 keyed hash (MAC)
 	/// \param key a byte array used to key the hash
-	/// \param keyLength the size of the byte array (must be 32 bytes)
+	/// \param keyLength the size of the byte array (must be exactly 32 bytes)
 	/// \param digestSize the digest size, in bytes (default 32)
+	/// \throw InvalidKeyLength if keyLength is not 32
+	/// \throw InvalidArgument if key is null, or if digestSize is 0 or larger than 1024
 	/// \since Crypto++ 8.9
 	BLAKE3(const byte *key, size_t keyLength, unsigned int digestSize = DIGESTSIZE);
 
 	/// \brief Construct a BLAKE3 key derivation function
-	/// \param context a string identifying the KDF context
+	/// \param context a string identifying the KDF context; a fixed, globally unique application string
 	/// \param digestSize the digest size, in bytes (default 32)
+	/// \throw InvalidArgument if context is null, or if digestSize is 0 or larger than 1024
 	/// \since Crypto++ 8.9
 	BLAKE3(const char* context, unsigned int digestSize = DIGESTSIZE);
 
@@ -167,6 +171,7 @@ public:
 	/// \param size the size of the truncated hash, in bytes
 	/// \details TruncatedFinal() calls Final() and then copies size bytes to hash.
 	///   The hash algorithm will be restarted ready for a new message.
+	/// \throw InvalidArgument if size is larger than the configured digest size
 	void TruncatedFinal(byte *hash, size_t size);
 
 	std::string AlgorithmProvider() const;

--- a/include/cryptopp/blake3.h
+++ b/include/cryptopp/blake3.h
@@ -101,8 +101,9 @@ struct CRYPTOPP_NO_VTABLE BLAKE3_State
 
 /// \brief The BLAKE3 cryptographic hash function
 /// \details BLAKE3 can function as a hash, keyed hash (MAC), or key derivation function.
-///   It supports variable-length output. The mode is determined at construction and
-///   cannot be changed. Use Restart() to reset the state while preserving the mode.
+///   It supports variable-length output. The constructor selects the initial
+///   mode; SetKey() switches the object to keyed mode and discards any buffered
+///   input. Restart() preserves the current mode and key.
 /// \sa BLAKE3 specification at <A HREF="https://github.com/BLAKE3-team/BLAKE3-specs">
 ///   BLAKE3-specs</A>
 /// \since Crypto++ 8.9

--- a/src/hash/blake3.cpp
+++ b/src/hash/blake3.cpp
@@ -325,10 +325,6 @@ unsigned int BLAKE3::OptimalDataAlignment() const
 	if (HasSSE41())
 		return 16;
 #endif
-#if CRYPTOPP_ARM_NEON_AVAILABLE
-	if (HasNEON())
-		return 16;
-#endif
 	return GetAlignmentOf<word32>();
 }
 
@@ -346,10 +342,6 @@ std::string BLAKE3::AlgorithmProvider() const
 	if (HasSSE41())
 		return "SSE4.1";
 #endif
-#if CRYPTOPP_ARM_NEON_AVAILABLE
-	if (HasNEON())
-		return "NEON";
-#endif
 	return "C++";
 }
 
@@ -358,7 +350,8 @@ std::string BLAKE3::AlgorithmProvider() const
 BLAKE3::BLAKE3(unsigned int digestSize)
 	: m_digestSize(digestSize)
 {
-	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
+	if (digestSize < 1 || digestSize > 1024)
+		throw InvalidArgument("BLAKE3: digest size must be 1 to 1024 bytes");
 	m_state.Reset();
 	m_state.m_flags = 0;
 	// Initialize key and chunk CV with IV for unkeyed mode
@@ -370,8 +363,12 @@ BLAKE3::BLAKE3(unsigned int digestSize)
 BLAKE3::BLAKE3(const byte *key, size_t keyLength, unsigned int digestSize)
 	: m_digestSize(digestSize)
 {
-	CRYPTOPP_ASSERT(keyLength == 32);
-	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
+	if (keyLength != 32)
+		throw InvalidKeyLength("BLAKE3", keyLength);
+	if (!key)
+		throw InvalidArgument("BLAKE3: key must not be null");
+	if (digestSize < 1 || digestSize > 1024)
+		throw InvalidArgument("BLAKE3: digest size must be 1 to 1024 bytes");
 
 	m_keyBytes.resize(keyLength);
 	std::memcpy(m_keyBytes.data(), key, keyLength);
@@ -391,7 +388,10 @@ BLAKE3::BLAKE3(const byte *key, size_t keyLength, unsigned int digestSize)
 BLAKE3::BLAKE3(const char* context, unsigned int digestSize)
 	: m_digestSize(digestSize)
 {
-	CRYPTOPP_ASSERT(digestSize >= 1 && digestSize <= 1024);
+	if (!context)
+		throw InvalidArgument("BLAKE3: KDF context must not be null");
+	if (digestSize < 1 || digestSize > 1024)
+		throw InvalidArgument("BLAKE3: digest size must be 1 to 1024 bytes");
 
 	m_state.Reset();
 
@@ -594,7 +594,7 @@ void BLAKE3::Update(const byte *input, size_t length)
 
 void BLAKE3::TruncatedFinal(byte *hash, size_t size)
 {
-	CRYPTOPP_ASSERT(size <= m_digestSize);
+	ThrowIfInvalidTruncatedSize(size);
 
 	// For single chunk (no tree), output from current chunk
 	if (m_state.m_cv_stack_len == 0) {
@@ -703,7 +703,10 @@ void BLAKE3::Restart()
 void BLAKE3::UncheckedSetKey(const byte* key, unsigned int length, const CryptoPP::NameValuePairs& params)
 {
 	CRYPTOPP_UNUSED(params);
-	CRYPTOPP_ASSERT(length == 32);
+	if (length != 32)
+		throw InvalidKeyLength("BLAKE3", length);
+	if (!key)
+		throw InvalidArgument("BLAKE3: key must not be null");
 
 	m_keyBytes.resize(length);
 	std::memcpy(m_keyBytes.data(), key, length);

--- a/src/hash/blake3.cpp
+++ b/src/hash/blake3.cpp
@@ -7,10 +7,9 @@
 #include <cryptopp/misc.h>
 #include <cryptopp/cpu.h>
 
-// Uncomment for benchmarking C++ against SSE4.1 or NEON.
+// Uncomment for benchmarking C++ against SSE4.1.
 // Do so in both blake3.cpp and blake3_simd.cpp.
 // #undef CRYPTOPP_SSE41_AVAILABLE
-// #undef CRYPTOPP_ARM_NEON_AVAILABLE
 
 NAMESPACE_BEGIN(CryptoPP)
 
@@ -710,6 +709,8 @@ void BLAKE3::UncheckedSetKey(const byte* key, unsigned int length, const CryptoP
 
 	m_keyBytes.resize(length);
 	std::memcpy(m_keyBytes.data(), key, length);
+
+	m_state.Reset();
 
 	for (size_t i = 0; i < 8; i++) {
 		m_state.m_key[i] = GetWord<word32>(false, LITTLE_ENDIAN_ORDER, key + i * 4);

--- a/src/hash/blake3_simd.cpp
+++ b/src/hash/blake3_simd.cpp
@@ -2,7 +2,7 @@
 //                   Colin Brown.
 //
 //    This source file uses intrinsics to gain access to SSE4.1 and
-//    ARM NEON instructions. A separate source file is needed because
+//    AVX2 instructions. A separate source file is needed because
 //    additional CXXFLAGS are required to enable the appropriate
 //    instruction sets in some build configurations.
 //
@@ -14,10 +14,9 @@
 #include <cryptopp/misc.h>
 #include <cryptopp/blake3.h>
 
-// Uncomment for benchmarking C++ against SSE4.1 or NEON.
+// Uncomment for benchmarking C++ against SSE4.1.
 // Do so in both blake3.cpp and blake3_simd.cpp.
 // #undef CRYPTOPP_SSE41_AVAILABLE
-// #undef CRYPTOPP_ARM_NEON_AVAILABLE
 
 #if (CRYPTOPP_SSE41_AVAILABLE)
 # include <emmintrin.h>
@@ -27,15 +26,6 @@
 
 #if (CRYPTOPP_AVX2_AVAILABLE)
 # include <immintrin.h>
-#endif
-
-#if (CRYPTOPP_ARM_NEON_HEADER)
-# include <arm_neon.h>
-#endif
-
-#if (CRYPTOPP_ARM_ACLE_HEADER)
-# include <stdint.h>
-# include <arm_acle.h>
 #endif
 
 // Squash MS LNK4221 and libtool warnings

--- a/src/test/validat5.cpp
+++ b/src/test/validat5.cpp
@@ -2359,6 +2359,109 @@ bool ValidateBLAKE3()
 		std::cout << (fail ? "FAILED   " : "passed   ") << "Empty string\n";
 	}
 
+	// Test 3: Malformed inputs are rejected at runtime
+	{
+		const byte shortKey[16] = {0};
+		const byte fullKey[32] = {0};
+		const byte longKey[33] = {0};
+		bool rejected;
+
+		rejected = false;
+		try { BLAKE3 mac(shortKey, sizeof(shortKey)); }
+		catch (const InvalidKeyLength &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects short key\n";
+
+		rejected = false;
+		try { BLAKE3 mac(longKey, sizeof(longKey)); }
+		catch (const InvalidKeyLength &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects oversize key\n";
+
+		rejected = false;
+		try { BLAKE3 mac(static_cast<const byte*>(NULLPTR), 32); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects null key\n";
+
+		rejected = false;
+		try { BLAKE3 mac(fullKey, sizeof(fullKey)); mac.SetKey(shortKey, sizeof(shortKey)); }
+		catch (const InvalidKeyLength &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "SetKey rejects short key\n";
+
+		rejected = false;
+		try { BLAKE3 mac; mac.SetKey(NULLPTR, 32); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "SetKey rejects null key\n";
+
+		rejected = false;
+		try { BLAKE3 kdf(static_cast<const char*>(NULLPTR)); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "KDF constructor rejects null context\n";
+
+		rejected = false;
+		try { BLAKE3 kdf(""); byte out[32]; kdf.TruncatedFinal(out, sizeof(out)); }
+		catch (const Exception &) { rejected = true; }
+		fail = rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "KDF constructor accepts empty context\n";
+
+		rejected = false;
+		try { BLAKE3 hash(0u); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Constructor rejects zero digest size\n";
+
+		rejected = false;
+		try { BLAKE3 mac(fullKey, sizeof(fullKey), 0); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects zero digest size\n";
+
+		rejected = false;
+		try { BLAKE3 hash(1025u); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Constructor rejects oversize digest\n";
+
+		rejected = false;
+		try { BLAKE3 kdf("test context", 1025); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "KDF constructor rejects oversize digest\n";
+
+		rejected = false;
+		try { BLAKE3 h1(1u); BLAKE3 h2(1024u); }
+		catch (const Exception &) { rejected = true; }
+		fail = rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Constructor accepts boundary digest sizes\n";
+
+		rejected = false;
+		try {
+			BLAKE3 hash;
+			byte out[64];
+			hash.TruncatedFinal(out, sizeof(out));
+		}
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "TruncatedFinal rejects oversize output\n";
+	}
+
 	// Use test vectors file for comprehensive testing
 	pass = RunTestDataFile("TestVectors/blake3.txt") && pass;
 

--- a/src/test/validat5.cpp
+++ b/src/test/validat5.cpp
@@ -2401,6 +2401,25 @@ bool ValidateBLAKE3()
 		pass = !fail && pass;
 		std::cout << (fail ? "FAILED   " : "passed   ") << "SetKey rejects null key\n";
 
+		fail = false;
+		try {
+			const byte prior[16] = {0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF,0x00};
+			const byte msg[16] = {0xDE,0xAD,0xBE,0xEF,0xCA,0xFE,0xBA,0xBE,0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77};
+			byte rekeyed[32], fresh[32];
+			BLAKE3 h;
+			h.Update(prior, sizeof(prior));
+			h.SetKey(fullKey, sizeof(fullKey));
+			h.Update(msg, sizeof(msg));
+			h.TruncatedFinal(rekeyed, sizeof(rekeyed));
+			BLAKE3 mac(fullKey, sizeof(fullKey));
+			mac.Update(msg, sizeof(msg));
+			mac.TruncatedFinal(fresh, sizeof(fresh));
+			fail = std::memcmp(rekeyed, fresh, sizeof(fresh)) != 0;
+		}
+		catch (const Exception &) { fail = true; }
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "SetKey resets state after prior use\n";
+
 		rejected = false;
 		try { BLAKE3 kdf(static_cast<const char*>(NULLPTR)); }
 		catch (const InvalidArgument &) { rejected = true; }
@@ -2428,6 +2447,20 @@ bool ValidateBLAKE3()
 		fail = !rejected;
 		pass = !fail && pass;
 		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects zero digest size\n";
+
+		rejected = false;
+		try { BLAKE3 mac(fullKey, sizeof(fullKey), 1025); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "Keyed constructor rejects oversize digest\n";
+
+		rejected = false;
+		try { BLAKE3 kdf("test context", 0); }
+		catch (const InvalidArgument &) { rejected = true; }
+		fail = !rejected;
+		pass = !fail && pass;
+		std::cout << (fail ? "FAILED   " : "passed   ") << "KDF constructor rejects zero digest size\n";
 
 		rejected = false;
 		try { BLAKE3 hash(1025u); }


### PR DESCRIPTION
Replaces BLAKE3's debug-only input assertions with runtime validation. Release builds previously allowed short or null keys, causing an out-of-bounds read in the keyed constructor, passed null KDF contexts to `strlen`, and accepted invalid digest and truncation sizes.

`AlgorithmProvider` also continued to report NEON after the NEON path was removed in #30.

## What changed

- The keyed constructor and `SetKey` now require exactly 32-byte keys. Incorrect lengths throw `InvalidKeyLength`, and null keys throw `InvalidArgument`.
- `SetKey` resets any buffered input and tree state before loading the new key.
- The keying trait is now `FixedKeyLength<32>`, changing `MIN_KEYLENGTH` from 0 to 32 and ensuring the framework `SetKey` path enforces the same requirement.
- The KDF constructor rejects null contexts. Empty contexts remain accepted for compatibility.
- All three constructors validate digest sizes from 1 to 1024 bytes, and `TruncatedFinal` uses the standard truncated-size check.
- `AlgorithmProvider` and `OptimalDataAlignment` no longer report or branch on NEON.
- `ValidateBLAKE3` adds 16 cases covering rejected inputs, rekeying, empty contexts, boundary digest sizes, and oversized truncation.