### PR TITLE
Reject zero PBKDF iterations without a positive time budget

### DIFF
--- a/include/cryptopp/pwdbased.h
+++ b/include/cryptopp/pwdbased.h
@@ -66,12 +66,14 @@ public:
 	/// \param timeInSeconds the in seconds
 	/// \return the number of iterations performed
 	/// \throw InvalidDerivedKeyLength if <tt>derivedLen</tt> is invalid for the scheme
+	/// \throw InvalidArgument for a zero iteration count without a positive <tt>timeInSeconds</tt>
 	/// \details DeriveKey() provides a standard interface to derive a key from
 	///   a seed and other parameters. Each class that derives from KeyDerivationFunction
 	///   provides an overload that accepts most parameters used by the derivation function.
 	/// \details If <tt>timeInSeconds</tt> is <tt>&gt; 0.0</tt> then DeriveKey will run for
 	///   the specified amount of time. If <tt>timeInSeconds</tt> is <tt>0.0</tt> then DeriveKey
-	///   will run for the specified number of iterations.
+	///   will run for the specified number of iterations. A zero iteration count is
+	///   rejected with InvalidArgument unless <tt>timeInSeconds</tt> is positive.
 	/// \details PKCS #5 says PBKDF1 should only take 8-byte salts. This implementation
 	///   allows salts of any length.
 	size_t DeriveKey(byte *derived, size_t derivedLen, byte purpose, const byte *secret, size_t secretLen, const byte *salt, size_t saltLen, unsigned int iterations, double timeInSeconds=0) const;
@@ -117,10 +119,14 @@ size_t PKCS5_PBKDF1<T>::DeriveKey(byte *derived, size_t derivedLen, byte purpose
 	CRYPTOPP_ASSERT(secret /*&& secretLen*/);
 	CRYPTOPP_ASSERT(derived && derivedLen);
 	CRYPTOPP_ASSERT(derivedLen <= MaxDerivedKeyLength());
-	CRYPTOPP_ASSERT(iterations > 0 || timeInSeconds > 0);
 	CRYPTOPP_UNUSED(purpose);
 
 	ThrowIfInvalidDerivedKeyLength(derivedLen);
+
+	// RFC 8018 defines the iteration count as a positive integer. A zero
+	// count is valid only with a positive time budget.
+	if (iterations == 0 && !(timeInSeconds > 0))
+		throw InvalidArgument("PKCS5_PBKDF1: zero iterations require a positive TimeInSeconds");
 
 	// Business logic
 	if (!iterations) { iterations = 1; }
@@ -196,12 +202,14 @@ public:
 	/// \param timeInSeconds the in seconds
 	/// \return the number of iterations performed
 	/// \throw InvalidDerivedKeyLength if <tt>derivedLen</tt> is invalid for the scheme
+	/// \throw InvalidArgument for a zero iteration count without a positive <tt>timeInSeconds</tt>
 	/// \details DeriveKey() provides a standard interface to derive a key from
 	///   a seed and other parameters. Each class that derives from KeyDerivationFunction
 	///   provides an overload that accepts most parameters used by the derivation function.
 	/// \details If <tt>timeInSeconds</tt> is <tt>&gt; 0.0</tt> then DeriveKey will run for
 	///   the specified amount of time. If <tt>timeInSeconds</tt> is <tt>0.0</tt> then DeriveKey
-	///   will run for the specified number of iterations.
+	///   will run for the specified number of iterations. A zero iteration count is
+	///   rejected with InvalidArgument unless <tt>timeInSeconds</tt> is positive.
 	size_t DeriveKey(byte *derived, size_t derivedLen, byte purpose, const byte *secret, size_t secretLen,
 	    const byte *salt, size_t saltLen, unsigned int iterations, double timeInSeconds=0) const;
 
@@ -246,10 +254,14 @@ size_t PKCS5_PBKDF2_HMAC<T>::DeriveKey(byte *derived, size_t derivedLen, byte pu
 	CRYPTOPP_ASSERT(secret /*&& secretLen*/);
 	CRYPTOPP_ASSERT(derived && derivedLen);
 	CRYPTOPP_ASSERT(derivedLen <= MaxDerivedKeyLength());
-	CRYPTOPP_ASSERT(iterations > 0 || timeInSeconds > 0);
 	CRYPTOPP_UNUSED(purpose);
 
 	ThrowIfInvalidDerivedKeyLength(derivedLen);
+
+	// RFC 8018 defines the iteration count as a positive integer. A zero
+	// count is valid only with a positive time budget.
+	if (iterations == 0 && !(timeInSeconds > 0))
+		throw InvalidArgument("PKCS5_PBKDF2_HMAC: zero iterations require a positive TimeInSeconds");
 
 	// Business logic
 	if (!iterations) { iterations = 1; }
@@ -357,12 +369,14 @@ public:
 	/// \param timeInSeconds the in seconds
 	/// \return the number of iterations performed
 	/// \throw InvalidDerivedKeyLength if <tt>derivedLen</tt> is invalid for the scheme
+	/// \throw InvalidArgument for a zero iteration count without a positive <tt>timeInSeconds</tt>
 	/// \details DeriveKey() provides a standard interface to derive a key from
 	///   a seed and other parameters. Each class that derives from KeyDerivationFunction
 	///   provides an overload that accepts most parameters used by the derivation function.
 	/// \details If <tt>timeInSeconds</tt> is <tt>&gt; 0.0</tt> then DeriveKey will run for
 	///   the specified amount of time. If <tt>timeInSeconds</tt> is <tt>0.0</tt> then DeriveKey
-	///   will run for the specified number of iterations.
+	///   will run for the specified number of iterations. A zero iteration count is
+	///   rejected with InvalidArgument unless <tt>timeInSeconds</tt> is positive.
 	size_t DeriveKey(byte *derived, size_t derivedLen, byte purpose, const byte *secret, size_t secretLen,
 	    const byte *salt, size_t saltLen, unsigned int iterations, double timeInSeconds) const;
 
@@ -408,9 +422,13 @@ size_t PKCS12_PBKDF<T>::DeriveKey(byte *derived, size_t derivedLen, byte purpose
 	CRYPTOPP_ASSERT(secret /*&& secretLen*/);
 	CRYPTOPP_ASSERT(derived && derivedLen);
 	CRYPTOPP_ASSERT(derivedLen <= MaxDerivedKeyLength());
-	CRYPTOPP_ASSERT(iterations > 0 || timeInSeconds > 0);
 
 	ThrowIfInvalidDerivedKeyLength(derivedLen);
+
+	// PKCS #12 applies the hash r times, which leaves a zero count with no
+	// meaning. A zero count is valid only with a positive time budget.
+	if (iterations == 0 && !(timeInSeconds > 0))
+		throw InvalidArgument("PKCS12_PBKDF: zero iterations require a positive TimeInSeconds");
 
 	// Business logic
 	if (!iterations) { iterations = 1; }

--- a/src/test/validat5.cpp
+++ b/src/test/validat5.cpp
@@ -45,6 +45,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <limits>
 
 // Aggressive stack checking with VS2005 SP1 and above.
 #if (_MSC_FULL_VER >= 140050727)
@@ -800,6 +801,106 @@ bool ValidatePBKDF()
 
 	std::cout << "\nPKCS #5 PBKDF2 validation suite running...\n\n";
 	pass = TestPBKDF(pbkdf, testSet, COUNTOF(testSet)) && pass;
+	}
+
+	{
+	// PBKDF2-HMAC-SHA-256, from RFC 7914 Section 11
+	PBKDF_TestTuple testSet[] =
+	{
+		{0, 1, "706173737764", "73616C74", "55AC046E56E3089FEC1691C22544B605F94185216DDE0465E68B9D57C20DACBC49CA9CCCF179B645991664B39D77EF317C71B845B1E30BD509112041D3A19783"},
+		{0, 80000, "50617373776F7264", "4E61436C", "4DDCD8F60B98BE21830CEE5EF22701F9641A4418D04C0414AEFF08876B34AB56A1D425A1225833549ADB841B51C9B3176A272BDEBBA1D078478F62B397F33C8D"}
+	};
+
+	PKCS5_PBKDF2_HMAC<SHA256> pbkdf;
+
+	std::cout << "\nPKCS #5 PBKDF2 HMAC-SHA256 validation suite running...\n\n";
+	pass = TestPBKDF(pbkdf, testSet, COUNTOF(testSet)) && pass;
+	}
+
+	{
+	// Zero iteration count without a positive time budget must be rejected
+	// (RFC 8018 defines the count as a positive integer). A zero count with
+	// a positive time budget remains valid; the loop then runs on time. The
+	// sentinel confirms rejection leaves the output buffer untouched.
+	std::cout << "\nPBKDF zero iteration count rejection suite running...\n\n";
+
+	const byte password[] = { 'p','a','s','s','w','o','r','d' };
+	const byte salt[] = { 's','a','l','t' };
+	const double qnan = std::numeric_limits<double>::quiet_NaN();
+	byte derived[32], sentinel[32];
+	std::memset(sentinel, 0xAA, sizeof(sentinel));
+	bool fail, rejected;
+
+	rejected = false;
+	std::memset(derived, 0xAA, sizeof(derived));
+	try {
+		PKCS5_PBKDF1<SHA1> kdf;
+		kdf.DeriveKey(derived, 16, 0, password, sizeof(password), salt, sizeof(salt), 0, 0.0);
+	}
+	catch (const InvalidArgument &) { rejected = true; }
+	fail = !rejected || std::memcmp(derived, sentinel, sizeof(derived)) != 0;
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS5_PBKDF1 rejects 0 iterations without time budget\n";
+
+	rejected = false;
+	std::memset(derived, 0xAA, sizeof(derived));
+	try {
+		PKCS5_PBKDF2_HMAC<SHA256> kdf;
+		kdf.DeriveKey(derived, sizeof(derived), 0, password, sizeof(password), salt, sizeof(salt), 0, 0.0);
+	}
+	catch (const InvalidArgument &) { rejected = true; }
+	fail = !rejected || std::memcmp(derived, sentinel, sizeof(derived)) != 0;
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS5_PBKDF2_HMAC rejects 0 iterations without time budget\n";
+
+	rejected = false;
+	std::memset(derived, 0xAA, sizeof(derived));
+	try {
+		PKCS5_PBKDF2_HMAC<SHA256> kdf;
+		kdf.DeriveKey(derived, sizeof(derived), 0, password, sizeof(password), salt, sizeof(salt), 0, qnan);
+	}
+	catch (const InvalidArgument &) { rejected = true; }
+	fail = !rejected || std::memcmp(derived, sentinel, sizeof(derived)) != 0;
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS5_PBKDF2_HMAC rejects 0 iterations with NaN time budget\n";
+
+	rejected = false;
+	std::memset(derived, 0xAA, sizeof(derived));
+	try {
+		PKCS12_PBKDF<SHA1> kdf;
+		kdf.DeriveKey(derived, 16, 1, password, sizeof(password), salt, sizeof(salt), 0, 0.0);
+	}
+	catch (const InvalidArgument &) { rejected = true; }
+	fail = !rejected || std::memcmp(derived, sentinel, sizeof(derived)) != 0;
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS12_PBKDF rejects 0 iterations without time budget\n";
+
+	fail = false;
+	try {
+		PKCS5_PBKDF1<SHA1> kdf;
+		fail = kdf.DeriveKey(derived, 16, 0, password, sizeof(password), salt, sizeof(salt), 0, 0.01) < 1;
+	}
+	catch (const Exception &) { fail = true; }
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS5_PBKDF1 accepts 0 iterations with time budget\n";
+
+	fail = false;
+	try {
+		PKCS5_PBKDF2_HMAC<SHA256> kdf;
+		fail = kdf.DeriveKey(derived, sizeof(derived), 0, password, sizeof(password), salt, sizeof(salt), 0, 0.01) < 1;
+	}
+	catch (const Exception &) { fail = true; }
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS5_PBKDF2_HMAC accepts 0 iterations with time budget\n";
+
+	fail = false;
+	try {
+		PKCS12_PBKDF<SHA1> kdf;
+		fail = kdf.DeriveKey(derived, 16, 1, password, sizeof(password), salt, sizeof(salt), 0, 0.01) < 1;
+	}
+	catch (const Exception &) { fail = true; }
+	pass = !fail && pass;
+	std::cout << (fail ? "FAILED   " : "passed   ") << "PKCS12_PBKDF accepts 0 iterations with time budget\n";
 	}
 
 	return pass;


### PR DESCRIPTION
Reported upstream as weidai11/cryptopp#1366.

PBKDF1, PBKDF2, and the PKCS #12 KDF silently treated zero iterations as one when no positive time budget was supplied.

Reject that input with `InvalidArgument` while preserving the existing timed mode where zero iterations are paired with a positive time budget.

Add rejection tests for all three KDFs, NaN handling, timed-mode controls, output-buffer preservation, and PBKDF2-HMAC-SHA256 vectors from RFC 7914.