### PR TITLE
Start the shared library ABI series at 9

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -159,14 +159,14 @@ Unix shared builds compile with default symbol visibility, so the full API is ex
 The SONAME carries an ABI version that is independent of the calendar release version. It comes from the `CRYPTOPP_ABI_VERSION` macro in `include/cryptopp/config_ver.h`, is read by both the CMake and GNUmakefile builds, and increments only for ABI-incompatible changes. On Linux the installed files look like:
 
 ```
-libcryptopp.so            -> libcryptopp.so.1
-libcryptopp.so.1          -> libcryptopp.so.2026.7.1    (SONAME)
+libcryptopp.so            -> libcryptopp.so.9
+libcryptopp.so.9          -> libcryptopp.so.2026.7.1    (SONAME)
 libcryptopp.so.2026.7.1                                 (real file)
 ```
 
 On macOS the ABI version sets the dylib `compatibility_version` and the release version sets `current_version`.
 
-The ABI series is independent of upstream Crypto++'s (`libcryptopp.so.8`). The two runtime libraries can be installed side by side, and a binary linked against one never binds to the other.
+The ABI series continues from upstream Crypto++'s `libcryptopp.so.8`: cryptopp-modern is based on the 8.x ABI line and includes public API additions, so `libcryptopp.so.9` identifies it as the next ABI generation. The two runtime libraries can be installed side by side, and a binary linked against one never binds to the other.
 
 ## Using cryptopp-modern in Your CMake Project
 

--- a/include/cryptopp/config_ver.h
+++ b/include/cryptopp/config_ver.h
@@ -64,7 +64,10 @@
 ///  compatibility version. It is independent of CRYPTOPP_VERSION and the
 ///  calendar release cycle, and increments only for ABI-incompatible
 ///  changes. The CMake and GNUmakefile builds both read this value.
-#define CRYPTOPP_ABI_VERSION 1
+/// \details The series starts at 9: cryptopp-modern is based on the
+///  Crypto++ 8.x ABI line (libcryptopp.so.8) with incompatible public API
+///  additions, so its shared library is the next ABI generation.
+#define CRYPTOPP_ABI_VERSION 9
 
 // Compiler version macros
 


### PR DESCRIPTION
Moves `CRYPTOPP_ABI_VERSION` from 1 to 9 before 2026.8.0 becomes the first cryptopp-modern release to ship a shared library. cryptopp-modern is based on the Crypto++ 8.x ABI line and includes substantial public API additions, so `libcryptopp.so.9` identifies it as the next ABI generation after upstream's `libcryptopp.so.8`.

No release shipped `libcryptopp.so.1`, so this does not break a released ABI.

## What changed

- Updated `CRYPTOPP_ABI_VERSION` from 1 to 9 in `include/cryptopp/config_ver.h`, with a note explaining the lineage
- Updated the symlink example and ABI-series text in `CMAKE.md`

CMake, the GNUmakefile, and the CI SONAME checks all read the macro, so no build or CI changes are needed.

Verified locally that a shared-library configuration emits `-Wl,-soname,libcryptopp.so.9`.

Follows up #48.
