### PR TITLE
Fix cryptest visibility in Unix shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1502,6 +1502,15 @@ if(CRYPTOPP_BUILD_TESTING)
     # Match GNUmakefile behavior: always use .exe suffix (even on Linux/macOS)
     set_target_properties(cryptest PROPERTIES SUFFIX ".exe")
 
+    # cryptest instantiates library templates, so its RTTI must remain visible
+    # when linking against the shared library under libc++ (GH #64).
+    if(CRYPTOPP_BUILD_SHARED AND NOT WIN32)
+        set_target_properties(cryptest PROPERTIES
+            CXX_VISIBILITY_PRESET default
+            VISIBILITY_INLINES_HIDDEN OFF
+        )
+    endif()
+
     # Copy TestData and TestVectors to build directory so tests can run from there
     add_custom_command(
         TARGET cryptest POST_BUILD


### PR DESCRIPTION
In Unix shared builds, `cryptest` inherited hidden visibility while linking against `libcryptopp.so.9`. With libc++, RTTI did not match across the shared-library boundary, causing `std::bad_cast` before the tests ran.

What changed:
- Give `cryptest` default visibility in non-Windows shared builds, matching the existing shared-library target.
- Static builds, Windows builds, and the installed library are unchanged.
- Confirmed by the reporter on FreeBSD: the tests pass and aMule 3.0.1 runs against the rebuilt library.

Fixes #64
