### PR TITLE
Reject undersized OAEP blocks

### DIFF
--- a/src/pubkey/oaep.cpp
+++ b/src/pubkey/oaep.cpp
@@ -19,8 +19,6 @@ size_t OAEP_Base::MaxUnpaddedLength(size_t paddedLength) const
 
 void OAEP_Base::Pad(RandomNumberGenerator &rng, const byte *input, size_t inputLength, byte *oaepBlock, size_t oaepBlockLen, const NameValuePairs &parameters) const
 {
-	CRYPTOPP_ASSERT (inputLength <= MaxUnpaddedLength(oaepBlockLen));
-
 	// convert from bit length to byte length
 	if (oaepBlockLen % 8 != 0)
 	{
@@ -31,7 +29,16 @@ void OAEP_Base::Pad(RandomNumberGenerator &rng, const byte *input, size_t inputL
 
 	member_ptr<HashTransformation> pHash(NewHash());
 	const size_t hLen = pHash->DigestSize();
-	const size_t seedLen = hLen, dbLen = oaepBlockLen-seedLen;
+	const size_t seedLen = hLen;
+
+	// DB must hold the digest, the 0x01 separator and the message. The second
+	// test is a subtraction so a large inputLength cannot overflow the bound.
+	if (oaepBlockLen < 2*hLen+1 || inputLength > oaepBlockLen-(2*hLen+1))
+		throw InvalidArgument("OAEP_Base::Pad: oaepBlock is too small for the digest and input");
+
+	CRYPTOPP_ASSERT(inputLength <= oaepBlockLen-(2*hLen+1));
+
+	const size_t dbLen = oaepBlockLen-seedLen;
 	byte *const maskedSeed = oaepBlock;
 	byte *const maskedDB = oaepBlock+seedLen;
 
@@ -64,9 +71,15 @@ DecodingResult OAEP_Base::Unpad(const byte *oaepBlock, size_t oaepBlockLen, byte
 
 	member_ptr<HashTransformation> pHash(NewHash());
 	const size_t hLen = pHash->DigestSize();
-	const size_t seedLen = hLen, dbLen = oaepBlockLen-seedLen;
+	const size_t seedLen = hLen;
 
-	invalid = (oaepBlockLen < 2*hLen+1) || invalid;
+	// A block this small cannot hold an encoding, and the dbLen computation
+	// below underflows. The block length and hash choice are public
+	// parameters, so returning early discloses nothing about the contents.
+	if (oaepBlockLen < 2*hLen+1)
+		return DecodingResult();
+
+	const size_t dbLen = oaepBlockLen-seedLen;
 
 	SecByteBlock t(oaepBlock, oaepBlockLen);
 	byte *const maskedSeed = t;

--- a/src/test/validat8.cpp
+++ b/src/test/validat8.cpp
@@ -222,6 +222,100 @@ bool ValidateRSA_Encrypt()
 		std::cout << (fail ? "FAILED    " : "passed    ");
 		std::cout << "PKCS 2.0 encryption and decryption\n";
 	}
+	{
+		// A block shorter than a seed, a digest and a separator cannot carry an
+		// OAEP encoding. Both directions must reject it rather than compute a
+		// length that underflows and walk off the block.
+		OAEP<SHA512> oaep;
+		const size_t hLen = SHA512::DIGESTSIZE;
+		const size_t blockLen = 2*hLen - 1;
+		SecByteBlock block(blockLen), recovered(blockLen), message(1);
+		std::memset(block, 0xa5, block.size());
+		std::memset(recovered, 0, recovered.size());
+		std::memset(message, 0x2a, message.size());
+
+		DecodingResult result = oaep.Unpad(block, 8*blockLen, recovered, g_nullNameValuePairs);
+		fail = result.isValidCoding || (result.messageLength != 0);
+
+		fail = (FindIfNot(recovered.begin(), recovered.end(), byte(0)) != recovered.end()) || fail;
+
+		try
+		{
+			oaep.Pad(GlobalRNG(), message, message.size(), block, 8*blockLen, g_nullNameValuePairs);
+			fail = true;
+		}
+		catch (const InvalidArgument&) {}
+
+		pass = pass && !fail;
+
+		std::cout << (fail ? "FAILED    " : "passed    ");
+		std::cout << "OAEP undersized block rejection\n";
+	}
+	{
+		// The smallest legal block is a seed, a digest and the separator, and
+		// carries an empty message. It must round trip, while one byte less is
+		// rejected in both directions.
+		OAEP<SHA512> oaep;
+		const size_t hLen = SHA512::DIGESTSIZE;
+		const size_t minLen = 2*hLen + 1;
+		SecByteBlock block(minLen), recovered(minLen), message(1);
+		std::memset(block, 0, block.size());
+		std::memset(recovered, 0xa5, recovered.size());
+		std::memset(message, 0x2a, message.size());
+
+		oaep.Pad(GlobalRNG(), message, 0, block, 8*minLen, g_nullNameValuePairs);
+		DecodingResult result = oaep.Unpad(block, 8*minLen, recovered, g_nullNameValuePairs);
+		fail = !result.isValidCoding || (result.messageLength != 0);
+
+		SecByteBlock shortBlock(minLen-1);
+		std::memset(shortBlock, 0, shortBlock.size());
+		std::memset(recovered, 0xa5, recovered.size());
+
+		result = oaep.Unpad(shortBlock, 8*(minLen-1), recovered, g_nullNameValuePairs);
+		fail = result.isValidCoding || (result.messageLength != 0) || fail;
+		fail = (FindIfNot(recovered.begin(), recovered.end(), byte(0xa5)) != recovered.end()) || fail;
+
+		try
+		{
+			oaep.Pad(GlobalRNG(), message, 0, shortBlock, 8*(minLen-1), g_nullNameValuePairs);
+			fail = true;
+		}
+		catch (const InvalidArgument&) {}
+
+		// A message one byte too long for the smallest legal block exercises
+		// the input-length half of the Pad guard rather than the block size.
+		try
+		{
+			oaep.Pad(GlobalRNG(), message, 1, block, 8*minLen, g_nullNameValuePairs);
+			fail = true;
+		}
+		catch (const InvalidArgument&) {}
+
+		pass = pass && !fail;
+
+		std::cout << (fail ? "FAILED    " : "passed    ");
+		std::cout << "OAEP minimum block size\n";
+	}
+	{
+		// The same defect through the public API: a modulus too small for
+		// SHA-512 OAEP reaches Unpad on every decrypt, valid ciphertext or not.
+		RSAES<OAEP<SHA512> >::Decryptor rsaPriv(GlobalRNG(), 1024);
+		SecByteBlock ct(rsaPriv.FixedCiphertextLength());
+		SecByteBlock pt(rsaPriv.MaxPlaintextLength(ct.size()) + 1);
+
+		// A small integer, so the value stays below the modulus and the private
+		// key operation does not fail its own consistency check.
+		std::memset(ct, 0, ct.size());
+		ct[ct.size()-1] = 2;
+		std::memset(pt, 0, pt.size());
+
+		DecodingResult result = rsaPriv.Decrypt(GlobalRNG(), ct, ct.size(), pt);
+		fail = result.isValidCoding || (result.messageLength != 0);
+		pass = pass && !fail;
+
+		std::cout << (fail ? "FAILED    " : "passed    ");
+		std::cout << "OAEP decryption with an undersized modulus\n";
+	}
 
 	return pass;
 }


### PR DESCRIPTION
Fixes an OAEP length underflow reported upstream in weidai11/cryptopp#1370. `OAEP_Base::Unpad` computed the DB length before checking the block size, so a modulus too small for the chosen hash underflowed the length and read beyond the block on every decrypt attempt using that key and hash combination. SHA-512 OAEP with an RSA-1024 key reaches this through the ordinary public API.

- `Unpad` now rejects blocks below the minimum encoding size before laying out the block.
- `Pad` applies the equivalent runtime bound and throws `InvalidArgument` instead of relying on a debug assertion.

Adds boundary tests pinning the exact minimum block size in both directions and an RSA-1024/SHA-512 decrypt regression test.
