### PR TITLE
Add a cryptest install option and fix its compiled-in data path

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -206,6 +206,10 @@ jobs:
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
         test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        # The default install ships cryptest and its data.
+        test -f build/install/bin/cryptest.exe
+        test -d build/install/share/cryptopp/TestData
+        test -d build/install/share/cryptopp/TestVectors
         # Both pkg-config names must resolve and yield usable flags; the
         # cryptopp-modern alias forwards to libcryptopp through Requires.
         export PKG_CONFIG_PATH="$PWD/build/install/lib/pkgconfig"
@@ -223,6 +227,28 @@ jobs:
           exit 1
         fi
         ls -la build/install/include/cryptopp/ | head -20
+
+    - name: Verify install without cryptest
+      run: |
+        # Keep cryptest available for CTest but omit it from this install.
+        cmake build/install-test -DCRYPTOPP_INSTALL_CRYPTEST=OFF
+        cmake --install build/install-test --prefix build/install-notest
+        test -f build/install-notest/lib/libcryptopp.a
+        test ! -e build/install-notest/bin/cryptest.exe
+        test ! -e build/install-notest/share/cryptopp/TestData
+        test ! -e build/install-notest/share/cryptopp/TestVectors
+
+    - name: Verify cryptest-only install
+      run: |
+        # Install cryptest as a tool with CRYPTOPP_BUILD_TESTING disabled.
+        cmake build/install-test -DCRYPTOPP_BUILD_TESTING=OFF -DCRYPTOPP_INSTALL_CRYPTEST=ON
+        cmake --build build/install-test --target cryptest -j"$(nproc)"
+        cmake --install build/install-test --prefix build/install-tools
+        test -f build/install-tools/bin/cryptest.exe
+        test -d build/install-tools/share/cryptopp/TestData
+        test -d build/install-tools/share/cryptopp/TestVectors
+        cd "$RUNNER_TEMP"
+        "$GITHUB_WORKSPACE/build/install-tools/bin/cryptest.exe" v
 
     - name: Test find_package integration
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -213,6 +213,10 @@ jobs:
         test -d build/install/include/cryptopp
         test -f build/install/include/cryptopp/aes.h
         test -f build/install/lib/cmake/cryptopp-modern/cryptopp-modernConfig.cmake
+        # The default install ships cryptest and its data.
+        test -f build/install/bin/cryptest.exe
+        test -d build/install/share/cryptopp/TestData
+        test -d build/install/share/cryptopp/TestVectors
         # Both pkg-config names must resolve and yield usable flags; the
         # cryptopp-modern alias forwards to libcryptopp through Requires.
         export PKG_CONFIG_PATH="$PWD/build/install/lib/pkgconfig"
@@ -230,6 +234,28 @@ jobs:
           exit 1
         fi
         ls -la build/install/include/cryptopp/ | head -20
+
+    - name: Verify install without cryptest
+      run: |
+        # Keep cryptest available for CTest but omit it from this install.
+        cmake build/install-test -DCRYPTOPP_INSTALL_CRYPTEST=OFF
+        cmake --install build/install-test --prefix build/install-notest
+        test -f build/install-notest/lib/libcryptopp.a
+        test ! -e build/install-notest/bin/cryptest.exe
+        test ! -e build/install-notest/share/cryptopp/TestData
+        test ! -e build/install-notest/share/cryptopp/TestVectors
+
+    - name: Verify cryptest-only install
+      run: |
+        # Install cryptest as a tool with CRYPTOPP_BUILD_TESTING disabled.
+        cmake build/install-test -DCRYPTOPP_BUILD_TESTING=OFF -DCRYPTOPP_INSTALL_CRYPTEST=ON
+        cmake --build build/install-test --target cryptest -j"$(nproc)"
+        cmake --install build/install-test --prefix build/install-tools
+        test -f build/install-tools/bin/cryptest.exe
+        test -d build/install-tools/share/cryptopp/TestData
+        test -d build/install-tools/share/cryptopp/TestVectors
+        cd "$RUNNER_TEMP"
+        "$GITHUB_WORKSPACE/build/install-tools/bin/cryptest.exe" v
 
     - name: Test find_package integration
       run: |

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -91,11 +91,14 @@ cmake --build --preset=debug
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `CRYPTOPP_BUILD_TESTING` | `ON` | Build the test executable (cryptest.exe) |
+| `CRYPTOPP_BUILD_TESTING` | `ON` | Build the test executable (cryptest.exe) and register the CTest suite |
 | `CRYPTOPP_INSTALL` | `ON` | Generate install targets |
+| `CRYPTOPP_INSTALL_CRYPTEST` | `CRYPTOPP_BUILD_TESTING` | Install cryptest.exe with its TestData and TestVectors. Set explicitly to install cryptest without the test suite, or to run the suite without installing cryptest |
 | `CRYPTOPP_BUILD_SHARED` | `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
 | `CRYPTOPP_USE_OPENMP` | `OFF` | Enable OpenMP for parallel algorithms |
 | `CRYPTOPP_INCLUDE_PREFIX` | `cryptopp` | Header installation directory name |
+
+`CRYPTOPP_INSTALL_CRYPTEST` takes its default from `CRYPTOPP_BUILD_TESTING` on the first configure of a build directory. Like all CMake options the value is then cached, so changing `CRYPTOPP_BUILD_TESTING` in an existing build directory does not re-derive it; set it explicitly or start from a fresh build directory. Installing cryptest also requires `CRYPTOPP_INSTALL` (which is `ON` by default).
 
 ### x86/x64 SIMD Options
 
@@ -227,8 +230,8 @@ cmake --install build
 | `lib/` | Static library (`libcryptopp.a` or `cryptopp.lib`) |
 | `lib/pkgconfig/` | pkg-config files (`libcryptopp.pc` and the `cryptopp-modern.pc` alias) |
 | `lib/cmake/cryptopp-modern/` | CMake config files for `find_package()` |
-| `share/cryptopp/` | TestData and TestVectors |
-| `bin/` | Test executable (`cryptest.exe`) |
+| `share/cryptopp/` | TestData and TestVectors (with `CRYPTOPP_INSTALL_CRYPTEST`) |
+| `bin/` | Test executable (`cryptest.exe`, with `CRYPTOPP_INSTALL_CRYPTEST`) |
 
 ## SIMD Auto-Detection
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,12 @@ option(CRYPTOPP_DISABLE_POWER9 "Disable POWER9" OFF)
 
 option(CRYPTOPP_BUILD_TESTING "Build library tests" ON)
 
+# Keep this after CRYPTOPP_BUILD_TESTING because its default follows that option.
+option(CRYPTOPP_INSTALL_CRYPTEST
+    "Install the cryptest tool and its test data"
+    "${CRYPTOPP_BUILD_TESTING}"
+)
+
 # Override the CRYPTOPP_INSTALL option to ON/OFF to respectively force
 # install/no-install behavior for cryptopp module.
 option(CRYPTOPP_INSTALL "Generate the install target for this project." ON)
@@ -1498,7 +1504,10 @@ target_link_libraries(
 # CRYPTOPP_DATA_DIR below depends on CMAKE_INSTALL_FULL_DATAROOTDIR.
 include(GNUInstallDirs)
 
-if(CRYPTOPP_BUILD_TESTING)
+if(
+    CRYPTOPP_BUILD_TESTING
+    OR (CRYPTOPP_INSTALL AND CRYPTOPP_INSTALL_CRYPTEST)
+)
     add_executable(cryptest ${cryptopp_SOURCES_TEST})
     target_link_libraries(cryptest PRIVATE cryptopp::cryptopp)
 
@@ -1514,7 +1523,7 @@ if(CRYPTOPP_BUILD_TESTING)
         )
     endif()
 
-    # Copy TestData and TestVectors to build directory so tests can run from there
+    # Keep build-tree cryptest runnable without relying on the source tree.
     add_custom_command(
         TARGET cryptest POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -1540,6 +1549,9 @@ if(CRYPTOPP_BUILD_TESTING)
                 CRYPTOPP_DATA_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/cryptopp/"
     )
 
+endif()
+
+if(CRYPTOPP_BUILD_TESTING)
     add_test(
         NAME cryptopp-modern-build_cryptest
         COMMAND
@@ -1640,15 +1652,21 @@ if(CRYPTOPP_INSTALL)
     )
 
     # Tests
-    if(CRYPTOPP_BUILD_TESTING)
-        install(TARGETS cryptest DESTINATION ${CMAKE_INSTALL_BINDIR})
+    if(CRYPTOPP_INSTALL_CRYPTEST)
+        install(
+            TARGETS cryptest
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT ${runtime}
+        )
         install(
             DIRECTORY ${cryptopp_SOURCE_DIR}/TestData
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cryptopp
+            COMPONENT ${runtime}
         )
         install(
             DIRECTORY ${cryptopp_SOURCE_DIR}/TestVectors
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cryptopp
+            COMPONENT ${runtime}
         )
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1495,6 +1495,9 @@ target_link_libraries(
 # Tests
 # ============================================================================
 
+# CRYPTOPP_DATA_DIR below depends on CMAKE_INSTALL_FULL_DATAROOTDIR.
+include(GNUInstallDirs)
+
 if(CRYPTOPP_BUILD_TESTING)
     add_executable(cryptest ${cryptopp_SOURCES_TEST})
     target_link_libraries(cryptest PRIVATE cryptopp::cryptopp)
@@ -1534,7 +1537,7 @@ if(CRYPTOPP_BUILD_TESTING)
         ${cryptopp_SOURCE_DIR}/src/test/validat9.cpp
         APPEND PROPERTY
             COMPILE_DEFINITIONS
-                CRYPTOPP_DATA_DIR="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/cryptopp/"
+                CRYPTOPP_DATA_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/cryptopp/"
     )
 
     add_test(
@@ -1579,8 +1582,6 @@ endif()
 # ==============================================================================
 # Deployment instructions
 # ==============================================================================
-
-include(GNUInstallDirs)
 
 if(CRYPTOPP_INSTALL)
     set(TARGETS_EXPORT_NAME "cryptopp-modern_Targets")


### PR DESCRIPTION
Add `CRYPTOPP_INSTALL_CRYPTEST` so packagers can install cryptest and its data without registering the CTest suite. The default follows `CRYPTOPP_BUILD_TESTING`, preserving existing behaviour for fresh configurations.

Also fix the compiled-in data path by loading GNUInstallDirs before it is used and using `CMAKE_INSTALL_FULL_DATAROOTDIR`.

Tested in the default, opt-out, and cryptest-only configurations on Linux, with installed-path verification on FreeBSD 14.3.