### PR TITLE
Handle absolute install dirs in pkg-config

### DIFF
--- a/cmake/ConfigFiles.cmake
+++ b/cmake/ConfigFiles.cmake
@@ -28,6 +28,16 @@ function(_module_pkgconfig_files)
     endif()
     set(MODULE_LINK_LIBS "-lcryptopp${target_debug_postfix}")
 
+    # Keep relative pkg-config paths relative to ${prefix}, but pass absolute
+    # GNUInstallDirs overrides through unchanged.
+    foreach(_dir LIBDIR INCLUDEDIR DATAROOTDIR)
+        if(IS_ABSOLUTE "${CMAKE_INSTALL_${_dir}}")
+            set(PC_${_dir} "${CMAKE_INSTALL_${_dir}}")
+        else()
+            set(PC_${_dir} "\${prefix}/${CMAKE_INSTALL_${_dir}}")
+        endif()
+    endforeach()
+
     # Primary file is named libcryptopp.pc to match upstream Crypto++, so
     # `pkg-config libcryptopp` keeps working for existing consumers.
     configure_file(

--- a/cmake/config.pc.in
+++ b/cmake/config.pc.in
@@ -1,9 +1,9 @@
 # cryptopp-modern package configuration file
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-datadir=${prefix}/@CMAKE_INSTALL_DATAROOTDIR@/cryptopp
+libdir=@PC_LIBDIR@
+includedir=@PC_INCLUDEDIR@
+datadir=@PC_DATAROOTDIR@/cryptopp
 
 Name: cryptopp-modern
 URL: https://github.com/cryptopp-modern/cryptopp-modern


### PR DESCRIPTION
The pkg-config template prepended `${prefix}` to absolute install directories, producing invalid paths under Nix.

Pass absolute paths through unchanged while preserving the existing output for relative paths. This lets nixpkgs drop its downstream workaround. See NixOS/nixpkgs#144170.