### PR TITLE
Flush the parent directory when creating a state file

### DIFF
--- a/include/cryptopp/stateful.h
+++ b/include/cryptopp/stateful.h
@@ -331,7 +331,14 @@ public:
     /// \param keyLen length of integrity key in bytes (0 if no key)
     /// \details Throws if file already exists. Silent overwrite is not
     ///  supported because it risks destroying valid signing state.
-    /// \throw Exception with IO_ERROR if file already exists or cannot be created
+    /// \details On POSIX the parent directory is flushed after the file so
+    ///  the new directory entry is durable before Create() returns. This
+    ///  needs read permission on the parent and a filesystem that supports
+    ///  fsync on a directory; a flush failure throws after the file has
+    ///  been created, so the state file may exist on disk after a throw.
+    ///  Windows flushes the file only, without a directory-entry guarantee.
+    /// \throw Exception with IO_ERROR if file already exists, cannot be
+    ///  created, or the file or parent directory cannot be flushed
     static FileStateStore Create(const std::string &path,
                                   uint64_t totalLeaves,
                                   const byte *integrityKey = NULLPTR,

--- a/src/pqc/stateful.cpp
+++ b/src/pqc/stateful.cpp
@@ -343,6 +343,40 @@ static void PlatformClose(int fd)
         close(fd);
 }
 
+// A new file's directory entry needs its own flush to be durable.
+static void PlatformFlushParentDir(const std::string &path)
+{
+    std::string dir;
+    std::string::size_type slash = path.find_last_of('/');
+    if (slash == std::string::npos)
+        dir = ".";
+    else if (slash == 0)
+        dir = "/";
+    else
+        dir = path.substr(0, slash);
+
+    int dfd;
+    do {
+        dfd = open(dir.c_str(), O_RDONLY
+#ifdef O_DIRECTORY
+            | O_DIRECTORY
+#endif
+        );
+    } while (dfd < 0 && errno == EINTR);
+    if (dfd < 0)
+        throw Exception(Exception::IO_ERROR,
+            "FileStateStore: cannot open parent directory for flush");
+
+    try {
+        PlatformFlush(dfd);
+    }
+    catch (...) {
+        PlatformClose(dfd);
+        throw;
+    }
+    PlatformClose(dfd);
+}
+
 #endif  // _WIN32
 
 // ---- HMAC helper ----
@@ -561,6 +595,7 @@ FileStateStore FileStateStore::Create(const std::string &path,
 #else
     PlatformWriteAt(store.m_fd, fileBuf, FILE_SIZE, 0);
     PlatformFlush(store.m_fd);
+    PlatformFlushParentDir(path);
 #endif
 
     return store;

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -26,6 +26,10 @@
 #  define NOMINMAX
 # endif
 # include <windows.h>
+#else
+# include <fcntl.h>
+# include <sys/stat.h>
+# include <unistd.h>
 #endif
 
 // Aggressive stack checking with VS2005 SP1 and above.
@@ -6402,6 +6406,89 @@ static bool TestFileStoreInProcessRollback()
 		return false;
 	}
 }
+
+static bool TestFileStoreCreateUnreadableParentDir()
+{
+	// POSIX only: Create() opens the parent directory to flush the new
+	// entry, which needs read permission. A write-and-search-only parent
+	// makes Create() throw after the file already exists.
+	const char* name = "FileStateStore (POSIX) unreadable parent dir";
+	const std::string dir = "test_filestore_noread_dir";
+	const std::string path = dir + "/state.state";
+
+	RemoveTestFile(path);
+	rmdir(dir.c_str());
+	if (mkdir(dir.c_str(), 0700) != 0) {
+		std::cout << "FAILED:  " << name << " test dir mkdir failed" << std::endl;
+		return false;
+	}
+	if (chmod(dir.c_str(), 0300) != 0) {
+		rmdir(dir.c_str());
+		std::cout << "FAILED:  " << name << " test dir chmod failed" << std::endl;
+		return false;
+	}
+
+	// Some filesystems accept the chmod without enforcing it (DrvFs, FAT,
+	// some network mounts). Probe before asserting the failure.
+	int probe;
+	do {
+		probe = open(dir.c_str(), O_RDONLY);
+	} while (probe < 0 && errno == EINTR);
+	if (probe >= 0) {
+		close(probe);
+		chmod(dir.c_str(), 0700);
+		rmdir(dir.c_str());
+		std::cout << "passed:  " << name
+			<< " (skipped: permissions not enforced)" << std::endl;
+		return true;
+	}
+	if (errno != EACCES && errno != EPERM) {
+		chmod(dir.c_str(), 0700);
+		rmdir(dir.c_str());
+		std::cout << "FAILED:  " << name << " probe open failed" << std::endl;
+		return false;
+	}
+
+	bool threw = false;
+	try {
+		FileStateStore store = FileStateStore::Create(path, 4);
+	}
+	catch (const Exception &e) {
+		if (e.GetErrorType() == Exception::IO_ERROR)
+			threw = true;
+	}
+	catch (...) {
+		// Restore permissions before cleanup.
+		chmod(dir.c_str(), 0700);
+		RemoveTestFile(path);
+		rmdir(dir.c_str());
+		throw;
+	}
+	chmod(dir.c_str(), 0700);
+
+	// The directory flush is the last step of Create(), so the throw
+	// leaves the complete 64-byte state file behind.
+	struct stat st;
+	const bool fileIntact = (stat(path.c_str(), &st) == 0
+		&& S_ISREG(st.st_mode) && st.st_size == 64);
+
+	RemoveTestFile(path);
+	rmdir(dir.c_str());
+
+	if (!threw) {
+		std::cout << "FAILED:  " << name
+			<< " Create() succeeded without parent read permission" << std::endl;
+		return false;
+	}
+	if (!fileIntact) {
+		std::cout << "FAILED:  " << name
+			<< " state file not intact after post-create failure" << std::endl;
+		return false;
+	}
+
+	std::cout << "passed:  " << name << std::endl;
+	return true;
+}
 #endif  // !_WIN32
 
 static bool TestZeroCapacityRejection()
@@ -6594,6 +6681,7 @@ bool ValidateFileStateStore()
 #ifndef _WIN32
 	pass = TestFileStoreConcurrentOpenRejected() && pass;
 	pass = TestFileStoreInProcessRollback() && pass;
+	pass = TestFileStoreCreateUnreadableParentDir() && pass;
 #endif
 	pass = TestFileStoreLMSIntegration() && pass;
 	pass = TestFileStoreHSSIntegration() && pass;


### PR DESCRIPTION
`FileStateStore::Create()` flushed the new state file but not its parent directory. On POSIX, a power loss immediately after `Create()` returned could therefore lose the directory entry.

Flush the parent directory after flushing the file, and fail if either flush fails. A failure after the file has been written may leave the state file in place, so document this behaviour in the header.

Add a POSIX test for an unreadable parent directory, skipping it where permission bits are not enforced. The update path and Windows behaviour are unchanged.