### PR TITLE
Avoid deprecated enum arithmetic in C++20

### DIFF
--- a/include/cryptopp/lms.h
+++ b/include/cryptopp/lms.h
@@ -47,7 +47,8 @@ struct LMOTS_SHA256_N32_W1
     CRYPTOPP_CONSTANT(U = 256);    // ceil(8*N/W) = message coefficients
     CRYPTOPP_CONSTANT(LS = 7);
     CRYPTOPP_CONSTANT(SIG_LEN = 4 + 32 + 265 * 32);  // 8516
-    static_assert(SIG_LEN == 4 + N + P * N, "LMOTS W1 SIG_LEN mismatch");
+    static_assert(SIG_LEN == 4 + EnumToInt(N) + EnumToInt(P) * EnumToInt(N),
+        "LMOTS W1 SIG_LEN mismatch");
 
     /// \brief Algorithm name
     static std::string StaticAlgorithmName() { return "LMOTS-SHA256-N32-W1"; }
@@ -65,7 +66,8 @@ struct LMOTS_SHA256_N32_W2
     CRYPTOPP_CONSTANT(U = 128);    // ceil(8*N/W) = message coefficients
     CRYPTOPP_CONSTANT(LS = 6);
     CRYPTOPP_CONSTANT(SIG_LEN = 4 + 32 + 133 * 32);  // 4292
-    static_assert(SIG_LEN == 4 + N + P * N, "LMOTS W2 SIG_LEN mismatch");
+    static_assert(SIG_LEN == 4 + EnumToInt(N) + EnumToInt(P) * EnumToInt(N),
+        "LMOTS W2 SIG_LEN mismatch");
 
     /// \brief Algorithm name
     static std::string StaticAlgorithmName() { return "LMOTS-SHA256-N32-W2"; }
@@ -83,7 +85,8 @@ struct LMOTS_SHA256_N32_W4
     CRYPTOPP_CONSTANT(U = 64);    // ceil(8*N/W) = message coefficients
     CRYPTOPP_CONSTANT(LS = 4);
     CRYPTOPP_CONSTANT(SIG_LEN = 4 + 32 + 67 * 32);  // 2180
-    static_assert(SIG_LEN == 4 + N + P * N, "LMOTS W4 SIG_LEN mismatch");
+    static_assert(SIG_LEN == 4 + EnumToInt(N) + EnumToInt(P) * EnumToInt(N),
+        "LMOTS W4 SIG_LEN mismatch");
 
     /// \brief Algorithm name
     static std::string StaticAlgorithmName() { return "LMOTS-SHA256-N32-W4"; }

--- a/src/hash/blake3.cpp
+++ b/src/hash/blake3.cpp
@@ -420,7 +420,8 @@ void BLAKE3::Update(const byte *input, size_t length)
 	while (length > 0) {
 		// If current chunk is full, finalize it and start new chunk
 		if (m_state.m_chunk.m_buf_len == BLOCKSIZE &&
-		    m_state.m_chunk.m_blocks_compressed * BLOCKSIZE >= CHUNKSIZE - BLOCKSIZE) {
+		    m_state.m_chunk.m_blocks_compressed * BLOCKSIZE >=
+		        EnumToInt(CHUNKSIZE) - EnumToInt(BLOCKSIZE)) {
 
 			word32 chunk_cv[8];
 			ChunkStateOutput(m_state.m_chunk, chunk_cv);

--- a/src/pqc/lms.cpp
+++ b/src/pqc/lms.cpp
@@ -676,7 +676,7 @@ template <class LMS_PARAMS, class OTS_PARAMS>
 void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // Library PKCS#8 wrapping with LMS OID. Version 0 only.
-    const size_t privKeyLen = SEED_SIZE + I_SIZE;
+    const size_t privKeyLen = EnumToInt(SEED_SIZE) + EnumToInt(I_SIZE);
 
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
@@ -1284,7 +1284,7 @@ void HSSPrivateKey<HSS_PARAMS>::DEREncode(BufferedTransformation &bt) const
 template <class HSS_PARAMS>
 void HSSPrivateKey<HSS_PARAMS>::BERDecode(BufferedTransformation &bt)
 {
-    const size_t privKeyLen = SEED_SIZE + I_SIZE;
+    const size_t privKeyLen = EnumToInt(SEED_SIZE) + EnumToInt(I_SIZE);
 
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;

--- a/src/pqc/xwing.cpp
+++ b/src/pqc/xwing.cpp
@@ -109,7 +109,8 @@ const byte* XWingPrivateKey::GetMLKEMPublicKeyPtr() const
     // Public key starts at offset SECRET_KEY_SIZE - PUBLIC_KEY_SIZE - 32 - 32
     // Actually for ML-KEM-768: sk (1152) || pk (1184) || H(pk) (32) || z (32) = 2400
     // Public key is at offset 1152
-    return m_mlkem_sk.begin() + (MLKEM_768::SECRET_KEY_SIZE - MLKEM_768::PUBLIC_KEY_SIZE - 32 - 32);
+    return m_mlkem_sk.begin() + (EnumToInt(MLKEM_768::SECRET_KEY_SIZE) -
+        EnumToInt(MLKEM_768::PUBLIC_KEY_SIZE) - 32 - 32);
 }
 
 void XWingPrivateKey::GetPublicKey(byte *publicKey) const


### PR DESCRIPTION
GCC 13 warns when constants declared by `CRYPTOPP_CONSTANT` are combined in C++20 builds.

Use `EnumToInt` at the three reported LMS assertions and four other locations found in the same sweep.
Fixes #79.