### PR TITLE
Fix BLAKE3 warnings and x86 feature checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,7 +663,7 @@ if(
         check_compile_link_option(${aesni_flag} CRYPTOPP_HAVE_AESNI
                                   "${TEST_PROG_DIR}/test_x86_aes.cpp"
         )
-        if(CRYPTOPP_HAVE_CLMUL)
+        if(CRYPTOPP_HAVE_AESNI)
             list(APPEND CRYPTOPP_AES_FLAGS "${aesni_flag}")
             list(APPEND CRYPTOPP_SM4_FLAGS "${aesni_flag}")
             list(APPEND CRYPTOPP_SUN_LDFLAGS "${aesni_flag}")
@@ -674,7 +674,7 @@ if(
         check_compile_link_option(${avx_flag} CRYPTOPP_HAVE_AVX
                                   "${TEST_PROG_DIR}/test_x86_avx.cpp"
         )
-        if(CRYPTOPP_HAVE_CLMUL)
+        if(CRYPTOPP_HAVE_AVX)
             list(APPEND CRYPTOPP_SUN_LDFLAGS "${avx_flag}")
         else()
             set(avx_flag "")
@@ -683,7 +683,7 @@ if(
         check_compile_link_option(${avx2_flag} CRYPTOPP_HAVE_AVX2
                                   "${TEST_PROG_DIR}/test_x86_avx2.cpp"
         )
-        if(CRYPTOPP_HAVE_CLMUL)
+        if(CRYPTOPP_HAVE_AVX2)
             # BLAKE3 AVX2 needs both SSE4.1 (for fallback) and AVX2
             list(APPEND CRYPTOPP_BLAKE3_AVX2_FLAGS "${sse41_flag}" "${avx2_flag}")
             list(APPEND CRYPTOPP_CHACHA_AVX2_FLAGS "${avx2_flag}")

--- a/src/hash/blake3_avx512.cpp
+++ b/src/hash/blake3_avx512.cpp
@@ -29,13 +29,13 @@ extern const word32 BLAKE3_IV[8];
 // Message schedule for BLAKE3 - 7 rounds
 extern const byte BLAKE3_MSG_SCHEDULE[7][16];
 
+#if (CRYPTOPP_AVX512F_AVAILABLE) && (CRYPTOPP_AVX512VL_AVAILABLE)
+
 // BLAKE3 constants
 static const size_t BLAKE3_BLOCK_LEN = 64;
 static const size_t BLAKE3_CHUNK_LEN = 1024;
 static const byte BLAKE3_CHUNK_START = 1;
 static const byte BLAKE3_CHUNK_END = 2;
-
-#if (CRYPTOPP_AVX512F_AVAILABLE) && (CRYPTOPP_AVX512VL_AVAILABLE)
 
 // AVX512 helper macros and functions
 #define LOADU512(p)    _mm512_loadu_si512((const __m512i *)(const void*)(p))

--- a/src/hash/blake3_simd.cpp
+++ b/src/hash/blake3_simd.cpp
@@ -39,11 +39,15 @@ extern const word32 BLAKE3_IV[8];
 // Message schedule for BLAKE3 - 7 rounds
 extern const byte BLAKE3_MSG_SCHEDULE[7][16];
 
+#if (CRYPTOPP_SSE41_AVAILABLE) || (CRYPTOPP_AVX2_AVAILABLE)
+
 // BLAKE3 constants
 static const size_t BLAKE3_BLOCK_LEN = 64;
 static const size_t BLAKE3_CHUNK_LEN = 1024;
 static const byte BLAKE3_CHUNK_START = 1;
 static const byte BLAKE3_CHUNK_END = 2;
+
+#endif
 
 #if CRYPTOPP_SSE41_AVAILABLE
 


### PR DESCRIPTION
The BLAKE3 SIMD constants were defined even when the x86 paths that use them were not built, producing AppleClang warnings on arm64. Move them under the same feature guards.

While checking the x86 detection, fix the AES-NI, AVX and AVX2 blocks to use their own test results instead of the CLMUL result.

The LMS warnings in the report were already fixed in #74.

Closes #81.