### PR TITLE
Harden PQC key decoding and encoding

### DIFF
--- a/include/cryptopp/hss.h
+++ b/include/cryptopp/hss.h
@@ -425,7 +425,12 @@ public:
 
     void SetPrivateKey(const byte *seed, size_t seedLen,
                        const byte *identifier, size_t idLen);
+    /// \brief Get pointer to secret seed
+    /// \return pointer to SEED_SIZE bytes, or NULL until a key is set
     const byte* GetSeedBytePtr() const { return m_seed.begin(); }
+
+    /// \brief Get pointer to identifier I
+    /// \return pointer to I_SIZE bytes, or NULL until a key is set
     const byte* GetIdentifierBytePtr() const { return m_I.begin(); }
 
     /// \brief Compute the HSS public key

--- a/include/cryptopp/hss.h
+++ b/include/cryptopp/hss.h
@@ -385,6 +385,9 @@ public:
     const byte* GetRootLMSPublicKey() const { return m_pk.begin() + 4; }
 
     /// \brief DER encode (X.509 SubjectPublicKeyInfo, RFC 9802)
+    /// \details A key whose L field or root LMS/LM-OTS typecodes do not
+    ///  match HSS_PARAMS throws InvalidArgument before any output is
+    ///  written. This covers default-constructed keys.
     void DEREncode(BufferedTransformation &bt) const;
     void BERDecode(BufferedTransformation &bt);
     void Save(BufferedTransformation &bt) const override { DEREncode(bt); }
@@ -407,7 +410,7 @@ public:
     CRYPTOPP_CONSTANT(SEED_SIZE = HSS_PARAMS::template OTSParamsAt<0>::N);
     CRYPTOPP_CONSTANT(I_SIZE = 16);
 
-    HSSPrivateKey() : m_seed(SEED_SIZE), m_I(I_SIZE) {}
+    HSSPrivateKey() {}
     virtual ~HSSPrivateKey() = default;
 
     /// \brief Get the algorithm OID
@@ -431,6 +434,8 @@ public:
     /// \brief Library PKCS#8 wrapping
     /// \details For cryptopp-modern persistence only. Not an RFC-defined
     ///  HSS private key format. Not portable across implementations.
+    ///  A key whose SEED or I is not at full size throws InvalidArgument
+    ///  before any output is written.
     void DEREncode(BufferedTransformation &bt) const;
     void BERDecode(BufferedTransformation &bt);
     void Save(BufferedTransformation &bt) const override { DEREncode(bt); }

--- a/include/cryptopp/lms.h
+++ b/include/cryptopp/lms.h
@@ -298,7 +298,7 @@ struct LMSPrivateKey : public PrivateKey
     CRYPTOPP_CONSTANT(SEED_SIZE = OTS_PARAMS::N);
     CRYPTOPP_CONSTANT(I_SIZE = 16);
 
-    LMSPrivateKey() : m_seed(SEED_SIZE), m_I(I_SIZE) {}
+    LMSPrivateKey() {}
     virtual ~LMSPrivateKey() = default;
 
     /// \brief Get the algorithm OID
@@ -345,6 +345,8 @@ struct LMSPrivateKey : public PrivateKey
     ///  format, not an RFC-standardised private key encoding.
     ///  Does not contain signing progress; reconstructing a
     ///  signer requires a valid state store.
+    ///  A key whose SEED or I is not at full size throws InvalidArgument
+    ///  before any output is written.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the private key (library PKCS#8 wrapping)

--- a/include/cryptopp/lms.h
+++ b/include/cryptopp/lms.h
@@ -327,9 +327,11 @@ struct LMSPrivateKey : public PrivateKey
                        const byte *identifier, size_t idLen);
 
     /// \brief Get pointer to secret seed
+    /// \return pointer to SEED_SIZE bytes, or NULL until a key is set
     const byte* GetSeedBytePtr() const { return m_seed.begin(); }
 
     /// \brief Get pointer to identifier I
+    /// \return pointer to I_SIZE bytes, or NULL until a key is set
     const byte* GetIdentifierBytePtr() const { return m_I.begin(); }
 
     /// \brief Compute the corresponding public key

--- a/include/cryptopp/mldsa.h
+++ b/include/cryptopp/mldsa.h
@@ -215,6 +215,8 @@ struct MLDSAPrivateKey : public PrivateKey
 
     /// \brief DER encode the private key (PKCS#8 OneAsymmetricKey format)
     /// \param bt BufferedTransformation to write to
+    /// \details A key whose material is not at full size throws
+    ///  InvalidArgument before any output is written.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the private key (PKCS#8 OneAsymmetricKey format)
@@ -279,6 +281,8 @@ struct MLDSAPublicKey : public PublicKey
 
     /// \brief DER encode the public key (X.509 SubjectPublicKeyInfo format)
     /// \param bt BufferedTransformation to write to
+    /// \details A key whose material is not at full size throws
+    ///  InvalidArgument before any output is written.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the public key (X.509 SubjectPublicKeyInfo format)

--- a/include/cryptopp/mlkem.h
+++ b/include/cryptopp/mlkem.h
@@ -24,6 +24,8 @@
 #include <cryptopp/asn.h>
 #include <cryptopp/oids.h>
 
+#include <cstring>
+
 NAMESPACE_BEGIN(CryptoPP)
 
 // ******************** Parameter Sets ************************* //
@@ -91,6 +93,7 @@ struct MLKEMPrivateKey : public PrivateKey
     CRYPTOPP_CONSTANT(SECRET_KEYLENGTH = PARAMS::SECRET_KEY_SIZE);
     CRYPTOPP_CONSTANT(PUBLIC_KEYLENGTH = PARAMS::PUBLIC_KEY_SIZE);
 
+    MLKEMPrivateKey() { std::memset(m_sk, 0, SECRET_KEYLENGTH); }
     virtual ~MLKEMPrivateKey() {}
 
     /// \brief Get the algorithm OID
@@ -137,6 +140,8 @@ struct MLKEMPrivateKey : public PrivateKey
 
     /// \brief DER encode the private key (PKCS#8 OneAsymmetricKey format)
     /// \param bt BufferedTransformation to write to
+    /// \details All-zero key material throws InvalidArgument before any
+    ///  output is written. This covers default-constructed keys.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the private key (PKCS#8 OneAsymmetricKey format)
@@ -165,6 +170,7 @@ struct MLKEMPublicKey : public PublicKey
 {
     CRYPTOPP_CONSTANT(PUBLIC_KEYLENGTH = PARAMS::PUBLIC_KEY_SIZE);
 
+    MLKEMPublicKey() { std::memset(m_pk, 0, PUBLIC_KEYLENGTH); }
     virtual ~MLKEMPublicKey() {}
 
     /// \brief Get the algorithm OID
@@ -200,6 +206,8 @@ struct MLKEMPublicKey : public PublicKey
 
     /// \brief DER encode the public key (X.509 SubjectPublicKeyInfo format)
     /// \param bt BufferedTransformation to write to
+    /// \details All-zero key material throws InvalidArgument before any
+    ///  output is written. This covers default-constructed keys.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the public key (X.509 SubjectPublicKeyInfo format)

--- a/include/cryptopp/slhdsa.h
+++ b/include/cryptopp/slhdsa.h
@@ -28,6 +28,7 @@
 #include <cryptopp/asn.h>
 #include <cryptopp/oids.h>
 
+#include <cstring>
 #include <vector>
 
 NAMESPACE_BEGIN(CryptoPP)
@@ -297,6 +298,11 @@ struct SLHDSAPrivateKey : public PrivateKey
     CRYPTOPP_CONSTANT(PUBLIC_KEYLENGTH = PARAMS::PUBLIC_KEY_SIZE);
     CRYPTOPP_CONSTANT(SIGNATURE_LENGTH = PARAMS::SIGNATURE_SIZE);
 
+    SLHDSAPrivateKey()
+    {
+        std::memset(m_sk, 0, SECRET_KEYLENGTH);
+        std::memset(m_pk, 0, PUBLIC_KEYLENGTH);
+    }
     virtual ~SLHDSAPrivateKey() {}
 
     /// \brief Get the algorithm OID
@@ -343,6 +349,8 @@ struct SLHDSAPrivateKey : public PrivateKey
 
     /// \brief DER encode the private key (PKCS#8 OneAsymmetricKey format)
     /// \param bt BufferedTransformation to write to
+    /// \details All-zero key material throws InvalidArgument before any
+    ///  output is written. This covers default-constructed keys.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the private key (PKCS#8 OneAsymmetricKey format)
@@ -373,6 +381,7 @@ struct SLHDSAPublicKey : public PublicKey
     CRYPTOPP_CONSTANT(PUBLIC_KEYLENGTH = PARAMS::PUBLIC_KEY_SIZE);
     CRYPTOPP_CONSTANT(SIGNATURE_LENGTH = PARAMS::SIGNATURE_SIZE);
 
+    SLHDSAPublicKey() { std::memset(m_pk, 0, PUBLIC_KEYLENGTH); }
     virtual ~SLHDSAPublicKey() {}
 
     /// \brief Get the algorithm OID
@@ -408,6 +417,8 @@ struct SLHDSAPublicKey : public PublicKey
 
     /// \brief DER encode the public key (X.509 SubjectPublicKeyInfo format)
     /// \param bt BufferedTransformation to write to
+    /// \details All-zero key material throws InvalidArgument before any
+    ///  output is written. This covers default-constructed keys.
     void DEREncode(BufferedTransformation &bt) const;
 
     /// \brief BER decode the public key (X.509 SubjectPublicKeyInfo format)

--- a/src/pqc/lms.cpp
+++ b/src/pqc/lms.cpp
@@ -678,6 +678,9 @@ void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::BERDecode(BufferedTransformation &bt
     // Library PKCS#8 wrapping with LMS OID. Version 0 only.
     const size_t privKeyLen = SEED_SIZE + I_SIZE;
 
+    SecByteBlock seed(SEED_SIZE);
+    SecByteBlock identifier(I_SIZE);
+
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
         BERDecodeUnsigned<word32>(privateKeyInfo, version, INTEGER, 0, 0);
@@ -693,15 +696,14 @@ void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::BERDecode(BufferedTransformation &bt
                 if (!privateKey.IsDefiniteLength() ||
                     privateKey.RemainingLength() != privKeyLen)
                     BERDecodeError();
-                SecByteBlock seed(SEED_SIZE);
-                SecByteBlock identifier(I_SIZE);
                 privateKey.Get(seed.begin(), SEED_SIZE);
                 privateKey.Get(identifier.begin(), I_SIZE);
-                SetPrivateKey(seed.begin(), SEED_SIZE, identifier.begin(), I_SIZE);
             privateKey.MessageEnd();
         octetString.MessageEnd();
 
     privateKeyInfo.MessageEnd();
+
+    SetPrivateKey(seed.begin(), SEED_SIZE, identifier.begin(), I_SIZE);
 }
 
 // ******************** LMSVerifier ************************* //
@@ -1165,6 +1167,8 @@ template <class HSS_PARAMS>
 void HSSPublicKey<HSS_PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // X.509 SubjectPublicKeyInfo (RFC 9802)
+    SecByteBlock subjectPublicKey;
+
     BERSequenceDecoder publicKeyInfo(bt);
         BERSequenceDecoder algorithm(publicKeyInfo);
             OID oid(algorithm);
@@ -1172,14 +1176,14 @@ void HSSPublicKey<HSS_PARAMS>::BERDecode(BufferedTransformation &bt)
                 BERDecodeError();
         algorithm.MessageEnd();
 
-        SecByteBlock subjectPublicKey;
         unsigned int unusedBits;
         BERDecodeBitString(publicKeyInfo, subjectPublicKey, unusedBits);
         if (unusedBits != 0 || subjectPublicKey.size() != PUBLIC_KEY_SIZE)
             BERDecodeError();
-        SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEY_SIZE);
 
     publicKeyInfo.MessageEnd();
+
+    SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEY_SIZE);
 }
 
 // ******************** HSSPrivateKey ************************* //
@@ -1286,6 +1290,9 @@ void HSSPrivateKey<HSS_PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     const size_t privKeyLen = SEED_SIZE + I_SIZE;
 
+    SecByteBlock seed(SEED_SIZE);
+    SecByteBlock identifier(I_SIZE);
+
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
         BERDecodeUnsigned<word32>(privateKeyInfo, version, INTEGER, 0, 0);
@@ -1301,15 +1308,14 @@ void HSSPrivateKey<HSS_PARAMS>::BERDecode(BufferedTransformation &bt)
                 if (!privateKey.IsDefiniteLength() ||
                     privateKey.RemainingLength() != privKeyLen)
                     BERDecodeError();
-                SecByteBlock seed(SEED_SIZE);
-                SecByteBlock identifier(I_SIZE);
                 privateKey.Get(seed.begin(), SEED_SIZE);
                 privateKey.Get(identifier.begin(), I_SIZE);
-                SetPrivateKey(seed.begin(), SEED_SIZE, identifier.begin(), I_SIZE);
             privateKey.MessageEnd();
         octetString.MessageEnd();
 
     privateKeyInfo.MessageEnd();
+
+    SetPrivateKey(seed.begin(), SEED_SIZE, identifier.begin(), I_SIZE);
 }
 
 // ******************** HSSVerifier ************************* //

--- a/src/pqc/lms.cpp
+++ b/src/pqc/lms.cpp
@@ -605,6 +605,9 @@ void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::MakePublicKey(
 {
     using namespace LMS_Internal;
 
+    if (m_seed.size() != SEED_SIZE || m_I.size() != I_SIZE)
+        throw InvalidArgument("LMSPrivateKey: invalid private key");
+
     const OTSParams otsP = MakeOTSParams<OTS_PARAMS>();
     const LMSParams lmsP = MakeLMSParams<LMS_PARAMS>();
 
@@ -652,6 +655,10 @@ void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::AssignFrom(const NameValuePairs &sou
 template <class LMS_PARAMS, class OTS_PARAMS>
 void LMSPrivateKey<LMS_PARAMS, OTS_PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    // Empty until GenerateRandom or SetPrivateKey; check before any output.
+    if (m_seed.size() != SEED_SIZE || m_I.size() != I_SIZE)
+        throw InvalidArgument("LMSPrivateKey: invalid private key");
+
     // Library PKCS#8 wrapping with LMS OID.
     // Private key payload is SEED || I (concatenated, no leaf index).
     // This is not an RFC-defined private key format.
@@ -803,6 +810,9 @@ LMSSigner<LMS_PARAMS, OTS_PARAMS>::LMSSigner(
     const PrivateKeyType &key, SignerStateStore &store)
     : m_key(key), m_store(&store)
 {
+    if (!m_key.Validate(NullRNG(), 0))
+        throw InvalidArgument("LMSSigner: invalid private key");
+
     // Precompute the Merkle tree on first construction.
     // Full tree stored in memory (suitable for H5/H10).
     using namespace LMS_Internal;
@@ -1152,6 +1162,15 @@ void HSSPublicKey<HSS_PARAMS>::AssignFrom(const NameValuePairs &source)
 template <class HSS_PARAMS>
 void HSSPublicKey<HSS_PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    // L and the root typecodes are zero on a default-constructed key.
+    typedef typename HSS_PARAMS::template LMSParamsAt<0> RootLMS_P;
+    typedef typename HSS_PARAMS::template OTSParamsAt<0> RootOTS_P;
+    if (m_pk.size() != PUBLIC_KEY_SIZE ||
+        GetL() != HSS_PARAMS::L ||
+        LMS_Internal::LoadBE32(m_pk + 4) != RootLMS_P::TYPE_ID ||
+        LMS_Internal::LoadBE32(m_pk + 8) != RootOTS_P::TYPE_ID)
+        throw InvalidArgument("HSSPublicKey: invalid public key");
+
     // X.509 SubjectPublicKeyInfo (RFC 9802)
     // AlgorithmIdentifier parameters MUST be absent (not NULL)
     DERSequenceEncoder publicKeyInfo(bt);
@@ -1217,6 +1236,9 @@ void HSSPrivateKey<HSS_PARAMS>::MakePublicKey(HSSPublicKey<HSS_PARAMS> &pub) con
 {
     using namespace LMS_Internal;
 
+    if (m_seed.size() != SEED_SIZE || m_I.size() != I_SIZE)
+        throw InvalidArgument("HSSPrivateKey: invalid private key");
+
     typedef typename HSS_PARAMS::template LMSParamsAt<0> RootLMS_P;
     typedef typename HSS_PARAMS::template OTSParamsAt<0> RootOTS_P;
 
@@ -1266,6 +1288,9 @@ void HSSPrivateKey<HSS_PARAMS>::AssignFrom(const NameValuePairs &source)
 template <class HSS_PARAMS>
 void HSSPrivateKey<HSS_PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    if (m_seed.size() != SEED_SIZE || m_I.size() != I_SIZE)
+        throw InvalidArgument("HSSPrivateKey: invalid private key");
+
     // Library PKCS#8 wrapping. Inner payload is SEED || I only;
     // level count and parameter types are carried by the template type.
     DERSequenceEncoder privateKeyInfo(bt);
@@ -1446,6 +1471,10 @@ template <class HSS_PARAMS>
 HSSSigner<HSS_PARAMS>::HSSSigner(const PrivateKeyType &key, SignerStateStore &store)
     : m_rootKey(key), m_store(&store), m_levels(HSS_PARAMS::L), m_reconciled(false)
 {
+    // ReconcileState reads m_rootKey; reject an unset key at construction.
+    if (!m_rootKey.Validate(NullRNG(), 0))
+        throw InvalidArgument("HSSSigner: invalid private key");
+
     // Lazy: no caches built here. First SignMessage() calls ReconcileState().
     for (unsigned int i = 0; i < HSS_PARAMS::L; i++)
         m_levels[i].initialised = false;

--- a/src/pqc/mldsa.cpp
+++ b/src/pqc/mldsa.cpp
@@ -1454,6 +1454,10 @@ void MLDSAPrivateKey<PARAMS>::SetPrivateKey(const byte *key, size_t len) {
 template <class PARAMS>
 void MLDSAPrivateKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    // m_sk is empty until the key is set; check before any output.
+    if (m_sk.size() != SECRET_KEYLENGTH)
+        throw InvalidArgument("MLDSAPrivateKey: invalid private key");
+
     // PKCS#8 OneAsymmetricKey format (RFC 5958)
     DERSequenceEncoder privateKeyInfo(bt);
         DEREncodeUnsigned<word32>(privateKeyInfo, 0);  // version
@@ -1537,6 +1541,9 @@ void MLDSAPublicKey<PARAMS>::SetPublicKey(const byte *key, size_t len) {
 template <class PARAMS>
 void MLDSAPublicKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    if (m_pk.size() != PUBLIC_KEYLENGTH)
+        throw InvalidArgument("MLDSAPublicKey: invalid public key");
+
     // X.509 SubjectPublicKeyInfo format (RFC 5280)
     DERSequenceEncoder publicKeyInfo(bt);
         DERSequenceEncoder algorithm(publicKeyInfo);

--- a/src/pqc/mldsa.cpp
+++ b/src/pqc/mldsa.cpp
@@ -1475,6 +1475,8 @@ template <class PARAMS>
 void MLDSAPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // PKCS#8 OneAsymmetricKey format (RFC 5958)
+    SecByteBlock sk(SECRET_KEYLENGTH);
+
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
         BERDecodeUnsigned<word32>(privateKeyInfo, version, INTEGER, 0, 1);
@@ -1490,13 +1492,17 @@ void MLDSAPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 if (!privateKey.IsDefiniteLength() ||
                     privateKey.RemainingLength() != SECRET_KEYLENGTH)
                     BERDecodeError();
-                SecByteBlock sk(SECRET_KEYLENGTH);
                 privateKey.Get(sk.begin(), SECRET_KEYLENGTH);
-                SetPrivateKey(sk.begin(), SECRET_KEYLENGTH);
             privateKey.MessageEnd();
         octetString.MessageEnd();
 
     privateKeyInfo.MessageEnd();
+
+    // SetPrivateKey can throw after updating m_sk. Stage and swap on success.
+    MLDSAPrivateKey<PARAMS> staged;
+    staged.SetPrivateKey(sk.begin(), SECRET_KEYLENGTH);
+    m_sk.swap(staged.m_sk);
+    m_pk.swap(staged.m_pk);
 }
 
 // MLDSAPublicKey implementation
@@ -1545,6 +1551,8 @@ template <class PARAMS>
 void MLDSAPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // X.509 SubjectPublicKeyInfo format (RFC 5280)
+    SecByteBlock subjectPublicKey;
+
     BERSequenceDecoder publicKeyInfo(bt);
         BERSequenceDecoder algorithm(publicKeyInfo);
             OID oid(algorithm);
@@ -1552,14 +1560,14 @@ void MLDSAPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 BERDecodeError();
         algorithm.MessageEnd();
 
-        SecByteBlock subjectPublicKey;
         unsigned int unusedBits;
         BERDecodeBitString(publicKeyInfo, subjectPublicKey, unusedBits);
         if (unusedBits != 0 || subjectPublicKey.size() != PUBLIC_KEYLENGTH)
             BERDecodeError();
-        SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 
     publicKeyInfo.MessageEnd();
+
+    SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 }
 
 // MLDSASigner implementation

--- a/src/pqc/mlkem.cpp
+++ b/src/pqc/mlkem.cpp
@@ -881,6 +881,15 @@ void mlkem_decaps(byte *ss, const byte *ct, const byte *sk)
 
 using namespace MLKEM_Internal;
 
+// Fixed-size key storage uses all zero as the unset sentinel.
+static bool IsAllZero(const byte *p, size_t n)
+{
+    byte acc = 0;
+    for (size_t i = 0; i < n; ++i)
+        acc |= p[i];
+    return acc == 0;
+}
+
 // ******************** MLKEMPrivateKey ************************* //
 
 template <class PARAMS>
@@ -940,6 +949,9 @@ void MLKEMPrivateKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
     //   privateKey                OCTET STRING,
     //   attributes            [0] IMPLICIT Attributes OPTIONAL,
     //   publicKey             [1] IMPLICIT PublicKey OPTIONAL }
+    if (IsAllZero(m_sk, SECRET_KEYLENGTH))
+        throw InvalidArgument("MLKEMPrivateKey: invalid private key");
+
     DERSequenceEncoder privateKeyInfo(bt);
         DEREncodeUnsigned<word32>(privateKeyInfo, 0);  // version
 
@@ -1050,6 +1062,9 @@ void MLKEMPublicKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
     // SubjectPublicKeyInfo  ::=  SEQUENCE  {
     //   algorithm            AlgorithmIdentifier,
     //   subjectPublicKey     BIT STRING  }
+    if (IsAllZero(m_pk, PUBLIC_KEYLENGTH))
+        throw InvalidArgument("MLKEMPublicKey: invalid public key");
+
     DERSequenceEncoder publicKeyInfo(bt);
         DERSequenceEncoder algorithm(publicKeyInfo);
             GetAlgorithmID().DEREncode(algorithm);

--- a/src/pqc/mlkem.cpp
+++ b/src/pqc/mlkem.cpp
@@ -960,6 +960,8 @@ template <class PARAMS>
 void MLKEMPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // PKCS#8 OneAsymmetricKey format (RFC 5958)
+    SecByteBlock sk(SECRET_KEYLENGTH);
+
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
         BERDecodeUnsigned<word32>(privateKeyInfo, version, INTEGER, 0, 1);
@@ -975,11 +977,13 @@ void MLKEMPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 if (!privateKey.IsDefiniteLength() ||
                     privateKey.RemainingLength() != SECRET_KEYLENGTH)
                     BERDecodeError();
-                privateKey.Get(m_sk.begin(), SECRET_KEYLENGTH);
+                privateKey.Get(sk.begin(), SECRET_KEYLENGTH);
             privateKey.MessageEnd();
         octetString.MessageEnd();
 
     privateKeyInfo.MessageEnd();
+
+    SetPrivateKey(sk.begin(), SECRET_KEYLENGTH);
 }
 
 // Explicit instantiations
@@ -1059,6 +1063,8 @@ template <class PARAMS>
 void MLKEMPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // X.509 SubjectPublicKeyInfo format (RFC 5280)
+    SecByteBlock subjectPublicKey;
+
     BERSequenceDecoder publicKeyInfo(bt);
         BERSequenceDecoder algorithm(publicKeyInfo);
             OID oid(algorithm);
@@ -1066,14 +1072,14 @@ void MLKEMPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 BERDecodeError();
         algorithm.MessageEnd();
 
-        SecByteBlock subjectPublicKey;
         unsigned int unusedBits;
         BERDecodeBitString(publicKeyInfo, subjectPublicKey, unusedBits);
         if (unusedBits != 0 || subjectPublicKey.size() != PUBLIC_KEYLENGTH)
             BERDecodeError();
-        std::memcpy(m_pk.begin(), subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 
     publicKeyInfo.MessageEnd();
+
+    SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 }
 
 // Explicit instantiations

--- a/src/pqc/slhdsa.cpp
+++ b/src/pqc/slhdsa.cpp
@@ -767,6 +767,8 @@ template <class PARAMS>
 void SLHDSAPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // PKCS#8 OneAsymmetricKey format (RFC 5958)
+    SecByteBlock sk(SECRET_KEYLENGTH);
+
     BERSequenceDecoder privateKeyInfo(bt);
         word32 version;
         BERDecodeUnsigned<word32>(privateKeyInfo, version, INTEGER, 0, 1);
@@ -782,13 +784,13 @@ void SLHDSAPrivateKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 if (!privateKey.IsDefiniteLength() ||
                     privateKey.RemainingLength() != SECRET_KEYLENGTH)
                     BERDecodeError();
-                SecByteBlock sk(SECRET_KEYLENGTH);
                 privateKey.Get(sk.begin(), SECRET_KEYLENGTH);
-                SetPrivateKey(sk.begin(), SECRET_KEYLENGTH);
             privateKey.MessageEnd();
         octetString.MessageEnd();
 
     privateKeyInfo.MessageEnd();
+
+    SetPrivateKey(sk.begin(), SECRET_KEYLENGTH);
 }
 
 // ******************** SLHDSAPublicKey Implementation ************************* //
@@ -842,6 +844,8 @@ template <class PARAMS>
 void SLHDSAPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
 {
     // X.509 SubjectPublicKeyInfo format (RFC 5280)
+    SecByteBlock subjectPublicKey;
+
     BERSequenceDecoder publicKeyInfo(bt);
         BERSequenceDecoder algorithm(publicKeyInfo);
             OID oid(algorithm);
@@ -849,14 +853,14 @@ void SLHDSAPublicKey<PARAMS>::BERDecode(BufferedTransformation &bt)
                 BERDecodeError();
         algorithm.MessageEnd();
 
-        SecByteBlock subjectPublicKey;
         unsigned int unusedBits;
         BERDecodeBitString(publicKeyInfo, subjectPublicKey, unusedBits);
         if (unusedBits != 0 || subjectPublicKey.size() != PUBLIC_KEYLENGTH)
             BERDecodeError();
-        SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 
     publicKeyInfo.MessageEnd();
+
+    SetPublicKey(subjectPublicKey.begin(), PUBLIC_KEYLENGTH);
 }
 
 // ******************** SLHDSASigner Implementation ************************* //

--- a/src/pqc/slhdsa.cpp
+++ b/src/pqc/slhdsa.cpp
@@ -697,6 +697,15 @@ static bool slh_verify(const byte *msg, size_t msg_len,
 
 } // anonymous namespace
 
+// Fixed-size key storage uses all zero as the unset sentinel.
+static bool IsAllZero(const byte *p, size_t n)
+{
+    byte acc = 0;
+    for (size_t i = 0; i < n; ++i)
+        acc |= p[i];
+    return acc == 0;
+}
+
 // ******************** SLHDSAPrivateKey Implementation ************************* //
 
 template <class PARAMS>
@@ -746,6 +755,9 @@ void SLHDSAPrivateKey<PARAMS>::SetPrivateKey(const byte *key, size_t len)
 template <class PARAMS>
 void SLHDSAPrivateKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    if (IsAllZero(m_sk, SECRET_KEYLENGTH))
+        throw InvalidArgument("SLHDSAPrivateKey: invalid private key");
+
     // PKCS#8 OneAsymmetricKey format (RFC 5958)
     DERSequenceEncoder privateKeyInfo(bt);
         DEREncodeUnsigned<word32>(privateKeyInfo, 0);  // version
@@ -830,6 +842,9 @@ void SLHDSAPublicKey<PARAMS>::SetPublicKey(const byte *key, size_t len)
 template <class PARAMS>
 void SLHDSAPublicKey<PARAMS>::DEREncode(BufferedTransformation &bt) const
 {
+    if (IsAllZero(m_pk, PUBLIC_KEYLENGTH))
+        throw InvalidArgument("SLHDSAPublicKey: invalid public key");
+
     // X.509 SubjectPublicKeyInfo format (RFC 5280)
     DERSequenceEncoder publicKeyInfo(bt);
         DERSequenceEncoder algorithm(publicKeyInfo);

--- a/src/test/validat11.cpp
+++ b/src/test/validat11.cpp
@@ -9,6 +9,7 @@
 #include <cryptopp/osrng.h>
 #include <cryptopp/hex.h>
 #include <cryptopp/filters.h>
+#include <cryptopp/sha.h>
 
 #include <cryptopp/mlkem.h>
 #include <cryptopp/mldsa.h>
@@ -259,6 +260,56 @@ static bool TestPqcEncodeGuard(const char* name, bool zeroIsUnset)
 	}
 	catch (const Exception& e) {
 		std::cout << "FAILED:  " << name << " unset-key encode rejection - " << e.what() << std::endl;
+		return false;
+	}
+}
+
+// Use deterministic key material to keep the DER digests reproducible.
+static void FillPattern(SecByteBlock& b, byte seed)
+{
+	for (size_t i = 0; i < b.size(); ++i)
+		b[i] = static_cast<byte>(seed + 3 * i);
+}
+
+template <class Key>
+static bool ExpectDerDigest(const char* name, const char* label, const Key& key,
+	const char* expected)
+{
+	std::string der, digest;
+	StringSink sink(der);
+	key.DEREncode(sink);
+	SHA256 hash;
+	StringSource(der, true, new HashFilter(hash, new HexEncoder(new StringSink(digest))));
+	if (digest != expected) {
+		std::cout << "FAILED:  " << name << " " << label << " DER digest " << digest << std::endl;
+		return false;
+	}
+	return true;
+}
+
+template <class PARAMS, class PubKey, class PrivKey>
+static bool TestPqcDerFixtures(const char* name, byte privSeed, const char* privDigest,
+	byte pubSeed, const char* pubDigest)
+{
+	try {
+		PrivKey priv;
+		SecByteBlock material(PARAMS::SECRET_KEY_SIZE);
+		FillPattern(material, privSeed);
+		priv.SetPrivateKey(material, material.size());
+		bool pass = ExpectDerDigest(name, "private", priv, privDigest);
+
+		PubKey pub;
+		material.New(PARAMS::PUBLIC_KEY_SIZE);
+		FillPattern(material, pubSeed);
+		pub.SetPublicKey(material, material.size());
+		pass = ExpectDerDigest(name, "public", pub, pubDigest) && pass;
+
+		if (pass)
+			std::cout << "passed:  " << name << " DER fixtures (2 keys)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " DER fixtures - " << e.what() << std::endl;
 		return false;
 	}
 }
@@ -602,6 +653,9 @@ bool ValidateMLKEM()
 	pass = TestMLKEMDecodeState<MLKEM_512>("ML-KEM-512") && pass;
 	pass = TestPqcEncodeGuard<MLKEM_512, MLKEMPublicKey<MLKEM_512>, MLKEMPrivateKey<MLKEM_512> >(
 		"ML-KEM-512", true) && pass;
+	pass = TestPqcDerFixtures<MLKEM_512, MLKEMPublicKey<MLKEM_512>, MLKEMPrivateKey<MLKEM_512> >("ML-KEM-512",
+		0x99, "444E0F29B287FF094184F0D3D35F72EE1E9B49844FB2228791A1AD0AD3663BD8",
+		0xaa, "6543C03D1B41D8D953760972D8230E53C81BFFACE194D07C560137D20AF10D48") && pass;
 
 	return pass;
 }
@@ -871,6 +925,9 @@ bool ValidateMLDSA()
 	pass = TestMLDSADecodeState<MLDSA_44>("ML-DSA-44") && pass;
 	pass = TestPqcEncodeGuard<MLDSA_44, MLDSAPublicKey<MLDSA_44>, MLDSAPrivateKey<MLDSA_44> >(
 		"ML-DSA-44", false) && pass;
+	pass = TestPqcDerFixtures<MLDSA_44, MLDSAPublicKey<MLDSA_44>, MLDSAPrivateKey<MLDSA_44> >("ML-DSA-44",
+		0x77, "7D22109CEF3717A65787BD69460EEC6F978413EF92A604BEF0CA8AFEFCE099FA",
+		0x88, "693E1FA426C9FE75B316AD56F2CBC3308219739A6AFBC2DB805D76D3575F8FDF") && pass;
 
 	return pass;
 }
@@ -1319,6 +1376,9 @@ bool ValidateSLHDSA()
 	pass = TestSLHDSADecodeState<SLHDSA_SHA2_128f>("SLH-DSA-SHA2-128f") && pass;
 	pass = TestPqcEncodeGuard<SLHDSA_SHA2_128f, SLHDSAPublicKey<SLHDSA_SHA2_128f>, SLHDSAPrivateKey<SLHDSA_SHA2_128f> >(
 		"SLH-DSA-SHA2-128f", true) && pass;
+	pass = TestPqcDerFixtures<SLHDSA_SHA2_128f, SLHDSAPublicKey<SLHDSA_SHA2_128f>, SLHDSAPrivateKey<SLHDSA_SHA2_128f> >("SLH-DSA-SHA2-128f",
+		0xbb, "77D041C07123CCEC0712990D7483BE51F68BA73CFDE9687316AE74577550B8D1",
+		0xcc, "CF8BE8CB315BB7D9C50AC16D6905D6AC6D6A7D12BF6E63BEF983D320972F2E47") && pass;
 
 	return pass;
 }

--- a/src/test/validat11.cpp
+++ b/src/test/validat11.cpp
@@ -32,6 +32,169 @@
 NAMESPACE_BEGIN(CryptoPP)
 NAMESPACE_BEGIN(Test)
 
+// ******************** PQC key decode-state helpers ************************* //
+
+// Grow the outer SEQUENCE by one trailing NULL, so decoding parses the key
+// payload and then fails at the outer MessageEnd. Handles short and long-form
+// length, including a short form that no longer fits after the increment.
+static std::string DerWithTrailingElementInSequence(const std::string& der)
+{
+	CRYPTOPP_ASSERT(!der.empty() && static_cast<byte>(der[0]) == 0x30);
+	const size_t extra = 2;  // one NULL: 0x05 0x00
+	std::string out = der;
+	byte first = static_cast<byte>(out[1]);
+	if (first < 0x80) {
+		size_t newLen = static_cast<size_t>(first) + extra;
+		if (newLen < 0x80) {
+			out[1] = static_cast<char>(newLen);
+		}
+		else {
+			out[1] = static_cast<char>(0x81);  // promote to one-byte long form
+			out.insert(out.begin() + 2, static_cast<char>(newLen));
+		}
+	}
+	else {
+		size_t n = first & 0x7F;
+		size_t carry = extra;
+		for (size_t i = 1 + n; i > 1 && carry; --i) {
+			size_t v = static_cast<byte>(out[i]) + carry;
+			out[i] = static_cast<char>(v & 0xFF);
+			carry = v >> 8;
+		}
+		CRYPTOPP_ASSERT(carry == 0);  // +2 never widens a real key's length field
+	}
+	out.push_back(static_cast<char>(0x05));
+	out.push_back(static_cast<char>(0x00));
+	return out;
+}
+
+// Rejected decodes must leave an existing key unchanged. Valid decodes must
+// stop at the end of the object and leave trailing input unread.
+// aBytes is encoded; bBytes is the key state that must survive failure.
+template <class PubKey>
+static bool TestPqcPublicDecodeState(const char* name,
+	const byte* aBytes, const byte* bBytes, size_t len)
+{
+	try {
+		if (VerifyBufsEqual(aBytes, bBytes, len)) {
+			std::cout << "FAILED:  " << name << " public test keys A and B identical" << std::endl;
+			return false;
+		}
+
+		PubKey keyA;
+		keyA.SetPublicKey(aBytes, len);
+		std::string der;
+		StringSink sink(der);
+		keyA.Save(sink);
+
+		PubKey target;
+		target.SetPublicKey(bBytes, len);
+
+		bool pass = true;
+		bool rejected = false;
+		try {
+			std::string malformed = DerWithTrailingElementInSequence(der);
+			StringSource src(malformed, true);
+			target.Load(src);
+		}
+		catch (const BERDecodeErr&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " public malformed stream accepted" << std::endl;
+			pass = false;
+		}
+		if (!VerifyBufsEqual(target.GetPublicKeyBytePtr(), bBytes, len)) {
+			std::cout << "FAILED:  " << name << " public key changed after rejected decode" << std::endl;
+			pass = false;
+		}
+
+		std::string withTail = der + "TAIL";
+		PubKey key;
+		StringSource src2(withTail, true);
+		key.Load(src2);
+		if (!VerifyBufsEqual(key.GetPublicKeyBytePtr(), aBytes, len)) {
+			std::cout << "FAILED:  " << name << " public boundary decode mismatch" << std::endl;
+			pass = false;
+		}
+		byte tail[4];
+		if (src2.MaxRetrievable() != 4 || src2.Get(tail, 4) != 4 ||
+			!VerifyBufsEqual(tail, reinterpret_cast<const byte*>("TAIL"), 4)) {
+			std::cout << "FAILED:  " << name << " public trailing bytes consumed" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " public decode state (2 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " public decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
+template <class PrivKey>
+static bool TestPqcPrivateDecodeState(const char* name,
+	const byte* aBytes, const byte* bBytes, size_t len)
+{
+	try {
+		if (VerifyBufsEqual(aBytes, bBytes, len)) {
+			std::cout << "FAILED:  " << name << " private test keys A and B identical" << std::endl;
+			return false;
+		}
+
+		PrivKey keyA;
+		keyA.SetPrivateKey(aBytes, len);
+		std::string der;
+		StringSink sink(der);
+		keyA.Save(sink);
+
+		PrivKey target;
+		target.SetPrivateKey(bBytes, len);
+		SecByteBlock targetPub(target.GetPublicKeyBytePtr(), target.GetPublicKeySize());
+
+		bool pass = true;
+		bool rejected = false;
+		try {
+			std::string malformed = DerWithTrailingElementInSequence(der);
+			StringSource src(malformed, true);
+			target.Load(src);
+		}
+		catch (const BERDecodeErr&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " private malformed stream accepted" << std::endl;
+			pass = false;
+		}
+		if (!VerifyBufsEqual(target.GetPrivateKeyBytePtr(), bBytes, len) ||
+			!VerifyBufsEqual(target.GetPublicKeyBytePtr(), targetPub, targetPub.size())) {
+			std::cout << "FAILED:  " << name << " private key changed after rejected decode" << std::endl;
+			pass = false;
+		}
+
+		std::string withTail = der + "TAIL";
+		PrivKey key;
+		StringSource src2(withTail, true);
+		key.Load(src2);
+		if (!VerifyBufsEqual(key.GetPrivateKeyBytePtr(), aBytes, len)) {
+			std::cout << "FAILED:  " << name << " private boundary decode mismatch" << std::endl;
+			pass = false;
+		}
+		byte tail[4];
+		if (src2.MaxRetrievable() != 4 || src2.Get(tail, 4) != 4 ||
+			!VerifyBufsEqual(tail, reinterpret_cast<const byte*>("TAIL"), 4)) {
+			std::cout << "FAILED:  " << name << " private trailing bytes consumed" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " private decode state (2 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " private decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 // ******************** ML-KEM Validation (FIPS 203) ************************* //
 
 template <class PARAMS>
@@ -321,6 +484,27 @@ static bool TestMLKEMDecapsKAT()
 	return true;
 }
 
+template <class PARAMS>
+static bool TestMLKEMDecodeState(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		MLKEMDecapsulator<PARAMS> a(rng), b(rng);
+		bool pass = true;
+		pass = TestPqcPublicDecodeState<MLKEMPublicKey<PARAMS> >(name,
+			a.GetKey().GetPublicKeyBytePtr(), b.GetKey().GetPublicKeyBytePtr(),
+			PARAMS::PUBLIC_KEY_SIZE) && pass;
+		pass = TestPqcPrivateDecodeState<MLKEMPrivateKey<PARAMS> >(name,
+			a.GetKey().GetPrivateKeyBytePtr(), b.GetKey().GetPrivateKeyBytePtr(),
+			PARAMS::SECRET_KEY_SIZE) && pass;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 bool ValidateMLKEM()
 {
 	std::cout << "\nML-KEM (FIPS 203) validation suite running...\n\n";
@@ -346,6 +530,8 @@ bool ValidateMLKEM()
 
 	// ACVP known-answer vectors, covering the implicit-rejection path
 	pass = TestMLKEMDecapsKAT() && pass;
+
+	pass = TestMLKEMDecodeState<MLKEM_512>("ML-KEM-512") && pass;
 
 	return pass;
 }
@@ -565,6 +751,27 @@ static bool TestMLDSAContext(const char* name)
 	}
 }
 
+template <class PARAMS>
+static bool TestMLDSADecodeState(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		MLDSASigner<PARAMS> a(rng), b(rng);
+		bool pass = true;
+		pass = TestPqcPublicDecodeState<MLDSAPublicKey<PARAMS> >(name,
+			a.GetKey().GetPublicKeyBytePtr(), b.GetKey().GetPublicKeyBytePtr(),
+			PARAMS::PUBLIC_KEY_SIZE) && pass;
+		pass = TestPqcPrivateDecodeState<MLDSAPrivateKey<PARAMS> >(name,
+			a.GetKey().GetPrivateKeyBytePtr(), b.GetKey().GetPrivateKeyBytePtr(),
+			PARAMS::SECRET_KEY_SIZE) && pass;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 bool ValidateMLDSA()
 {
 	std::cout << "\nML-DSA (FIPS 204) validation suite running...\n\n";
@@ -590,6 +797,8 @@ bool ValidateMLDSA()
 	pass = TestMLDSASignVerify<MLDSA_87>("ML-DSA-87") && pass;
 	pass = TestMLDSASerialization<MLDSA_87>("ML-DSA-87") && pass;
 	pass = TestMLDSASaveLoad<MLDSA_87>("ML-DSA-87") && pass;
+
+	pass = TestMLDSADecodeState<MLDSA_44>("ML-DSA-44") && pass;
 
 	return pass;
 }
@@ -982,6 +1191,27 @@ static bool TestSLHDSASigVerKAT()
 	return true;
 }
 
+template <class PARAMS>
+static bool TestSLHDSADecodeState(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		SLHDSASigner<PARAMS> a(rng), b(rng);
+		bool pass = true;
+		pass = TestPqcPublicDecodeState<SLHDSAPublicKey<PARAMS> >(name,
+			a.GetKey().GetPublicKeyBytePtr(), b.GetKey().GetPublicKeyBytePtr(),
+			PARAMS::PUBLIC_KEY_SIZE) && pass;
+		pass = TestPqcPrivateDecodeState<SLHDSAPrivateKey<PARAMS> >(name,
+			a.GetKey().GetPrivateKeyBytePtr(), b.GetKey().GetPrivateKeyBytePtr(),
+			PARAMS::SECRET_KEY_SIZE) && pass;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 bool ValidateSLHDSA()
 {
 	std::cout << "\nSLH-DSA (FIPS 205) validation suite running...\n\n";
@@ -1013,6 +1243,8 @@ bool ValidateSLHDSA()
 	// Higher security-level size checks
 	pass = TestSLHDSAKeyGen<SLHDSA_SHA2_192f>("SLH-DSA-SHA2-192f") && pass;
 	pass = TestSLHDSAKeyGen<SLHDSA_SHA2_256f>("SLH-DSA-SHA2-256f") && pass;
+
+	pass = TestSLHDSADecodeState<SLHDSA_SHA2_128f>("SLH-DSA-SHA2-128f") && pass;
 
 	return pass;
 }

--- a/src/test/validat11.cpp
+++ b/src/test/validat11.cpp
@@ -195,6 +195,74 @@ static bool TestPqcPrivateDecodeState(const char* name,
 	}
 }
 
+// Encoding a key that was never set must throw InvalidArgument and write
+// nothing. Once a key is set, the same object must encode.
+template <class Key>
+static bool ExpectPqcEncodeReject(const char* name, const char* label, const Key& key)
+{
+	ByteQueue queue;
+	bool rejected = false;
+	try {
+		key.DEREncode(queue);
+	}
+	catch (const InvalidArgument&) {
+		rejected = true;
+	}
+	if (!rejected) {
+		std::cout << "FAILED:  " << name << " " << label << " encoded" << std::endl;
+		return false;
+	}
+	if (queue.MaxRetrievable() != 0) {
+		std::cout << "FAILED:  " << name << " " << label << " wrote output" << std::endl;
+		return false;
+	}
+	return true;
+}
+
+// zeroIsUnset: the family stores keys in fixed-size blocks and treats
+// all-zero material as unset, so the setters must not defeat the guard.
+template <class PARAMS, class PubKey, class PrivKey>
+static bool TestPqcEncodeGuard(const char* name, bool zeroIsUnset)
+{
+	AutoSeededRandomPool rng;
+	try {
+		PubKey pub;
+		PrivKey priv;
+		bool pass = ExpectPqcEncodeReject(name, "default public", pub);
+		pass = ExpectPqcEncodeReject(name, "default private", priv) && pass;
+		unsigned int cases = 2;
+
+		if (zeroIsUnset) {
+			SecByteBlock zeros;
+			zeros.CleanNew(PARAMS::PUBLIC_KEY_SIZE);
+			pub.SetPublicKey(zeros, zeros.size());
+			pass = ExpectPqcEncodeReject(name, "all-zero public", pub) && pass;
+			zeros.CleanNew(PARAMS::SECRET_KEY_SIZE);
+			priv.SetPrivateKey(zeros, zeros.size());
+			pass = ExpectPqcEncodeReject(name, "all-zero private", priv) && pass;
+			cases += 2;
+		}
+
+		priv.GenerateRandom(rng, g_nullNameValuePairs);
+		pub.SetPublicKey(priv.GetPublicKeyBytePtr(), PARAMS::PUBLIC_KEY_SIZE);
+		ByteQueue pubQueue, privQueue;
+		pub.DEREncode(pubQueue);
+		priv.DEREncode(privQueue);
+		if (pubQueue.MaxRetrievable() == 0 || privQueue.MaxRetrievable() == 0) {
+			std::cout << "FAILED:  " << name << " set key encode" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " unset-key encode rejection (" << cases << " cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " unset-key encode rejection - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 // ******************** ML-KEM Validation (FIPS 203) ************************* //
 
 template <class PARAMS>
@@ -532,6 +600,8 @@ bool ValidateMLKEM()
 	pass = TestMLKEMDecapsKAT() && pass;
 
 	pass = TestMLKEMDecodeState<MLKEM_512>("ML-KEM-512") && pass;
+	pass = TestPqcEncodeGuard<MLKEM_512, MLKEMPublicKey<MLKEM_512>, MLKEMPrivateKey<MLKEM_512> >(
+		"ML-KEM-512", true) && pass;
 
 	return pass;
 }
@@ -799,6 +869,8 @@ bool ValidateMLDSA()
 	pass = TestMLDSASaveLoad<MLDSA_87>("ML-DSA-87") && pass;
 
 	pass = TestMLDSADecodeState<MLDSA_44>("ML-DSA-44") && pass;
+	pass = TestPqcEncodeGuard<MLDSA_44, MLDSAPublicKey<MLDSA_44>, MLDSAPrivateKey<MLDSA_44> >(
+		"ML-DSA-44", false) && pass;
 
 	return pass;
 }
@@ -1245,6 +1317,8 @@ bool ValidateSLHDSA()
 	pass = TestSLHDSAKeyGen<SLHDSA_SHA2_256f>("SLH-DSA-SHA2-256f") && pass;
 
 	pass = TestSLHDSADecodeState<SLHDSA_SHA2_128f>("SLH-DSA-SHA2-128f") && pass;
+	pass = TestPqcEncodeGuard<SLHDSA_SHA2_128f, SLHDSAPublicKey<SLHDSA_SHA2_128f>, SLHDSAPrivateKey<SLHDSA_SHA2_128f> >(
+		"SLH-DSA-SHA2-128f", true) && pass;
 
 	return pass;
 }

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -1971,6 +1971,181 @@ static bool TestLMSSigGenVerifyACVP()
 	}
 }
 
+// Grow the outer SEQUENCE by one trailing NULL, so decoding parses the key
+// payload and then fails at the outer MessageEnd. Handles short and long-form
+// length, including a short form that no longer fits after the increment.
+static std::string LmsDerWithTrailingElement(const std::string& der)
+{
+	CRYPTOPP_ASSERT(!der.empty() && static_cast<byte>(der[0]) == 0x30);
+	const size_t extra = 2;  // one NULL: 0x05 0x00
+	std::string out = der;
+	byte first = static_cast<byte>(out[1]);
+	if (first < 0x80) {
+		size_t newLen = static_cast<size_t>(first) + extra;
+		if (newLen < 0x80) {
+			out[1] = static_cast<char>(newLen);
+		}
+		else {
+			out[1] = static_cast<char>(0x81);  // promote to one-byte long form
+			out.insert(out.begin() + 2, static_cast<char>(newLen));
+		}
+	}
+	else {
+		size_t n = first & 0x7F;
+		size_t carry = extra;
+		for (size_t i = 1 + n; i > 1 && carry; --i) {
+			size_t v = static_cast<byte>(out[i]) + carry;
+			out[i] = static_cast<char>(v & 0xFF);
+			carry = v >> 8;
+		}
+		CRYPTOPP_ASSERT(carry == 0);  // +2 never widens a real key's length field
+	}
+	out.push_back(static_cast<char>(0x05));
+	out.push_back(static_cast<char>(0x00));
+	return out;
+}
+
+// Rejected decodes must leave an existing key unchanged. Valid decodes must
+// stop at the end of the object and leave trailing input unread. For LMS/HSS
+// private keys the state is SEED || I.
+template <class PrivKey>
+static bool TestStatefulPrivDecodeState(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		PrivKey keyA, target;
+		keyA.GenerateRandom(rng, g_nullNameValuePairs);
+		target.GenerateRandom(rng, g_nullNameValuePairs);
+
+		if (VerifyBufsEqual(keyA.GetSeedBytePtr(), target.GetSeedBytePtr(), PrivKey::SEED_SIZE) &&
+			VerifyBufsEqual(keyA.GetIdentifierBytePtr(), target.GetIdentifierBytePtr(), PrivKey::I_SIZE)) {
+			std::cout << "FAILED:  " << name << " private test keys A and B identical" << std::endl;
+			return false;
+		}
+
+		std::string der;
+		StringSink sink(der);
+		keyA.DEREncode(sink);
+
+		SecByteBlock bSeed(target.GetSeedBytePtr(), PrivKey::SEED_SIZE);
+		SecByteBlock bId(target.GetIdentifierBytePtr(), PrivKey::I_SIZE);
+
+		bool pass = true;
+		bool rejected = false;
+		try {
+			std::string malformed = LmsDerWithTrailingElement(der);
+			StringSource src(malformed, true);
+			target.BERDecode(src);
+		}
+		catch (const BERDecodeErr&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " private malformed stream accepted" << std::endl;
+			pass = false;
+		}
+		if (!VerifyBufsEqual(target.GetSeedBytePtr(), bSeed, PrivKey::SEED_SIZE) ||
+			!VerifyBufsEqual(target.GetIdentifierBytePtr(), bId, PrivKey::I_SIZE)) {
+			std::cout << "FAILED:  " << name << " private key changed after rejected decode" << std::endl;
+			pass = false;
+		}
+
+		std::string withTail = der + "TAIL";
+		PrivKey key;
+		StringSource src2(withTail, true);
+		key.BERDecode(src2);
+		if (!VerifyBufsEqual(key.GetSeedBytePtr(), keyA.GetSeedBytePtr(), PrivKey::SEED_SIZE) ||
+			!VerifyBufsEqual(key.GetIdentifierBytePtr(), keyA.GetIdentifierBytePtr(), PrivKey::I_SIZE)) {
+			std::cout << "FAILED:  " << name << " private boundary decode mismatch" << std::endl;
+			pass = false;
+		}
+		byte tail[4];
+		if (src2.MaxRetrievable() != 4 || src2.Get(tail, 4) != 4 ||
+			!VerifyBufsEqual(tail, reinterpret_cast<const byte*>("TAIL"), 4)) {
+			std::cout << "FAILED:  " << name << " private trailing bytes consumed" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " private decode state (2 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " private decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
+template <class HSS_PARAMS>
+static bool TestHSSPubDecodeState(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		typedef HSSPublicKey<HSS_PARAMS> PubKey;
+
+		HSSPrivateKey<HSS_PARAMS> privA, privB;
+		privA.GenerateRandom(rng, g_nullNameValuePairs);
+		privB.GenerateRandom(rng, g_nullNameValuePairs);
+		PubKey pubA, pubB;
+		privA.MakePublicKey(pubA);
+		privB.MakePublicKey(pubB);
+
+		const size_t len = PubKey::PUBLIC_KEY_SIZE;
+		SecByteBlock aBytes(pubA.GetPublicKeyBytePtr(), len);
+		SecByteBlock bBytes(pubB.GetPublicKeyBytePtr(), len);
+
+		if (VerifyBufsEqual(aBytes, bBytes, len)) {
+			std::cout << "FAILED:  " << name << " public test keys A and B identical" << std::endl;
+			return false;
+		}
+
+		std::string der;
+		StringSink sink(der);
+		pubA.DEREncode(sink);
+
+		PubKey target;
+		target.SetPublicKey(bBytes, len);
+
+		bool pass = true;
+		bool rejected = false;
+		try {
+			std::string malformed = LmsDerWithTrailingElement(der);
+			StringSource src(malformed, true);
+			target.BERDecode(src);
+		}
+		catch (const BERDecodeErr&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " public malformed stream accepted" << std::endl;
+			pass = false;
+		}
+		if (!VerifyBufsEqual(target.GetPublicKeyBytePtr(), bBytes, len)) {
+			std::cout << "FAILED:  " << name << " public key changed after rejected decode" << std::endl;
+			pass = false;
+		}
+
+		std::string withTail = der + "TAIL";
+		PubKey key;
+		StringSource src2(withTail, true);
+		key.BERDecode(src2);
+		if (!VerifyBufsEqual(key.GetPublicKeyBytePtr(), aBytes, len)) {
+			std::cout << "FAILED:  " << name << " public boundary decode mismatch" << std::endl;
+			pass = false;
+		}
+		byte tail[4];
+		if (src2.MaxRetrievable() != 4 || src2.Get(tail, 4) != 4 ||
+			!VerifyBufsEqual(tail, reinterpret_cast<const byte*>("TAIL"), 4)) {
+			std::cout << "FAILED:  " << name << " public trailing bytes consumed" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " public decode state (2 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " public decode state - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 bool ValidateLMS()
 {
 	std::cout << "\nLMS (SP 800-208) validation suite running...\n\n";
@@ -2016,6 +2191,8 @@ bool ValidateLMS()
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSSpkiEncode() && pass;
 	pass = TestLMSSpkiEncodeInvalid<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>(
+		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestStatefulPrivDecodeState<LMSPrivateKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8> >(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H5_W8_L1_Params>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
@@ -4814,6 +4991,10 @@ bool ValidateHSS()
 	pass = TestHSSMultipleSignatures<HSS_SHA256_H5_W8_L2_Params>(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestHSSSerialization<HSS_SHA256_H5_W8_L2_Params>(
+		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestHSSPubDecodeState<HSS_SHA256_H5_W8_L2_Params>(
+		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestStatefulPrivDecodeState<HSSPrivateKey<HSS_SHA256_H5_W8_L2_Params> >(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestHSSRFCAppendixFTC1() && pass;
 	pass = TestHSSRFCAppendixFTC2() && pass;

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -2146,6 +2146,61 @@ static bool TestStatefulUnsetKey(const char* name, uint64_t leaves)
 	}
 }
 
+// Use deterministic key material to keep the DER digests reproducible.
+static void FillPattern(SecByteBlock& b, byte seed)
+{
+	for (size_t i = 0; i < b.size(); ++i)
+		b[i] = static_cast<byte>(seed + 3 * i);
+}
+
+template <class Key>
+static bool ExpectDerDigest(const char* name, const char* label, const Key& key,
+	const char* expected)
+{
+	std::string der, digest;
+	StringSink sink(der);
+	key.DEREncode(sink);
+	SHA256 hash;
+	StringSource(der, true, new HashFilter(hash, new HexEncoder(new StringSink(digest))));
+	if (digest != expected) {
+		std::cout << "FAILED:  " << name << " " << label << " DER digest " << digest << std::endl;
+		return false;
+	}
+	return true;
+}
+
+// header holds the typecode fields a public key must carry to encode:
+// LMS typecode || LM-OTS typecode for LMS, L || both typecodes for HSS.
+template <class PrivKey, class PubKey>
+static bool TestStatefulDerFixtures(const char* name, byte seedSeed, byte idSeed,
+	const char* privDigest, byte pubSeed, const byte* header, size_t headerLen,
+	const char* pubDigest)
+{
+	try {
+		PrivKey priv;
+		SecByteBlock seed(PrivKey::SEED_SIZE), id(PrivKey::I_SIZE);
+		FillPattern(seed, seedSeed);
+		FillPattern(id, idSeed);
+		priv.SetPrivateKey(seed, seed.size(), id, id.size());
+		bool pass = ExpectDerDigest(name, "private", priv, privDigest);
+
+		PubKey pub;
+		SecByteBlock material(PubKey::PUBLIC_KEY_SIZE);
+		FillPattern(material, pubSeed);
+		std::memcpy(material, header, headerLen);
+		pub.SetPublicKey(material, material.size());
+		pass = ExpectDerDigest(name, "public", pub, pubDigest) && pass;
+
+		if (pass)
+			std::cout << "passed:  " << name << " DER fixtures (2 keys)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " DER fixtures - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 template <class HSS_PARAMS>
 static bool TestHSSPubDecodeState(const char* name)
 {
@@ -2319,6 +2374,14 @@ bool ValidateLMS()
 		LMSPublicKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>,
 		LMSSigner<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8> >(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8", LMS_SHA256_M32_H5::TOTAL_LEAVES) && pass;
+	{
+		static const byte header[] = { 0, 0, 0, 5, 0, 0, 0, 4 };  // H5, W8
+		pass = TestStatefulDerFixtures<LMSPrivateKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>,
+			LMSPublicKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8> >("LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8",
+			0x11, 0x22, "8837CF0FCE0E69910FE7B27F2B331BC2E9EE16FAC5E009E07AE272EB903B68BD",
+			0x33, header, sizeof(header),
+			"DEC692584D5916B1D02273BE4DADAE980A6922B0F20526199F52FDC0E97C5F63") && pass;
+	}
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H5_W8_L1_Params>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H10_W8_L1_Params>(
@@ -5127,6 +5190,14 @@ bool ValidateHSS()
 		HSSPublicKey<HSS_SHA256_H5_W8_L2_Params>, HSSSigner<HSS_SHA256_H5_W8_L2_Params> >(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8",
 		HSS_SHA256_H5_W8_L2_Params::TotalSignatures()) && pass;
+	{
+		static const byte header[] = { 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 4 };  // L=1, H5, W8
+		pass = TestStatefulDerFixtures<HSSPrivateKey<HSS_SHA256_H5_W8_L1_Params>,
+			HSSPublicKey<HSS_SHA256_H5_W8_L1_Params> >("HSS[1]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8",
+			0x44, 0x55, "4EEB06BD224AC46C8F2D15FD816620B20AA5DA3D23239A0779E6FDB82850CCA2",
+			0x66, header, sizeof(header),
+			"EF7F3B2CA6E89B6EA1165458922B0195C289D82B5AC9FDFD1DC5B299E324EAA3") && pass;
+	}
 	pass = TestHSSRFCAppendixFTC1() && pass;
 	pass = TestHSSRFCAppendixFTC2() && pass;
 	pass = TestHSSMalformedSignatures() && pass;

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -2101,6 +2101,51 @@ static bool TestLMSPrivateEncodeGuard(const char* name)
 	}
 }
 
+// Unset private keys must fail validation, public-key derivation and
+// signer construction.
+template <class PrivKey, class PubKey, class Signer>
+static bool TestStatefulUnsetKey(const char* name, uint64_t leaves)
+{
+	try {
+		PrivKey key;
+		bool pass = true;
+		if (key.Validate(NullRNG(), 0)) {
+			std::cout << "FAILED:  " << name << " unset private key validated" << std::endl;
+			pass = false;
+		}
+
+		bool rejected = false;
+		try {
+			PubKey pub;
+			key.MakePublicKey(pub);
+		}
+		catch (const InvalidArgument&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " unset private key derived a public key" << std::endl;
+			pass = false;
+		}
+
+		rejected = false;
+		InsecureMemoryStateStore store(leaves);
+		try {
+			Signer signer(key, store);
+		}
+		catch (const InvalidArgument&) { rejected = true; }
+		if (!rejected) {
+			std::cout << "FAILED:  " << name << " unset private key constructed a signer" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " unset private key rejection (3 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " unset private key rejection - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 template <class HSS_PARAMS>
 static bool TestHSSPubDecodeState(const char* name)
 {
@@ -2270,6 +2315,10 @@ bool ValidateLMS()
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSPrivateEncodeGuard<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestStatefulUnsetKey<LMSPrivateKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>,
+		LMSPublicKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>,
+		LMSSigner<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8> >(
+		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8", LMS_SHA256_M32_H5::TOTAL_LEAVES) && pass;
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H5_W8_L1_Params>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H10_W8_L1_Params>(
@@ -5074,6 +5123,10 @@ bool ValidateHSS()
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestHSSEncodeGuard<HSS_SHA256_H5_W8_L2_Params>(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestStatefulUnsetKey<HSSPrivateKey<HSS_SHA256_H5_W8_L2_Params>,
+		HSSPublicKey<HSS_SHA256_H5_W8_L2_Params>, HSSSigner<HSS_SHA256_H5_W8_L2_Params> >(
+		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8",
+		HSS_SHA256_H5_W8_L2_Params::TotalSignatures()) && pass;
 	pass = TestHSSRFCAppendixFTC1() && pass;
 	pass = TestHSSRFCAppendixFTC2() && pass;
 	pass = TestHSSMalformedSignatures() && pass;

--- a/src/test/validat12.cpp
+++ b/src/test/validat12.cpp
@@ -1066,9 +1066,8 @@ static bool TestLMSSpkiEncode()
 	return pass;
 }
 
-template <class LMS_PARAMS, class OTS_PARAMS>
-static bool ExpectLMSEncodeReject(const char* name, const char* label,
-	const LMSPublicKey<LMS_PARAMS, OTS_PARAMS>& key)
+template <class Key>
+static bool ExpectLMSEncodeReject(const char* name, const char* label, const Key& key)
 {
 	std::string encoded;
 	StringSink sink(encoded);
@@ -2074,6 +2073,34 @@ static bool TestStatefulPrivDecodeState(const char* name)
 	}
 }
 
+// A private key is empty until GenerateRandom or SetPrivateKey.
+template <class LMS_PARAMS, class OTS_PARAMS>
+static bool TestLMSPrivateEncodeGuard(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		LMSPrivateKey<LMS_PARAMS, OTS_PARAMS> key;
+		bool pass = ExpectLMSEncodeReject(name, "default-constructed private", key);
+
+		key.GenerateRandom(rng, g_nullNameValuePairs);
+		std::string encoded;
+		StringSink sink(encoded);
+		key.DEREncode(sink);
+		if (encoded.empty()) {
+			std::cout << "FAILED:  " << name << " set private key encode" << std::endl;
+			pass = false;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " unset private key encode rejection" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " unset private key encode rejection - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 template <class HSS_PARAMS>
 static bool TestHSSPubDecodeState(const char* name)
 {
@@ -2146,6 +2173,53 @@ static bool TestHSSPubDecodeState(const char* name)
 	}
 }
 
+// A default public key is full-sized and zero-filled, so L and both root
+// typecodes are wrong. The tampered cases flip one bit in each field.
+template <class HSS_PARAMS>
+static bool TestHSSEncodeGuard(const char* name)
+{
+	AutoSeededRandomPool rng;
+	try {
+		typedef HSSPublicKey<HSS_PARAMS> PubKey;
+
+		HSSPrivateKey<HSS_PARAMS> priv;
+		PubKey pub;
+		bool pass = ExpectLMSEncodeReject(name, "default-constructed private", priv);
+		pass = ExpectLMSEncodeReject(name, "default-constructed public", pub) && pass;
+
+		priv.GenerateRandom(rng, g_nullNameValuePairs);
+		priv.MakePublicKey(pub);
+		ByteQueue pubQueue, privQueue;
+		pub.DEREncode(pubQueue);
+		priv.DEREncode(privQueue);
+		if (pubQueue.MaxRetrievable() == 0 || privQueue.MaxRetrievable() == 0) {
+			std::cout << "FAILED:  " << name << " set key encode" << std::endl;
+			pass = false;
+		}
+
+		static const struct { size_t offset; const char* label; } tamper[] = {
+			{ 3, "mismatched L" },
+			{ 7, "mismatched LMS typecode" },
+			{ 11, "mismatched LM-OTS typecode" },
+		};
+		for (size_t i = 0; i < COUNTOF(tamper); ++i) {
+			SecByteBlock tampered(pub.GetPublicKeyBytePtr(), PubKey::PUBLIC_KEY_SIZE);
+			tampered[tamper[i].offset] ^= 0x01;
+			PubKey bad;
+			bad.SetPublicKey(tampered, tampered.size());
+			pass = ExpectLMSEncodeReject(name, tamper[i].label, bad) && pass;
+		}
+
+		if (pass)
+			std::cout << "passed:  " << name << " encode guard rejection (5 cases)" << std::endl;
+		return pass;
+	}
+	catch (const Exception& e) {
+		std::cout << "FAILED:  " << name << " encode guard rejection - " << e.what() << std::endl;
+		return false;
+	}
+}
+
 bool ValidateLMS()
 {
 	std::cout << "\nLMS (SP 800-208) validation suite running...\n\n";
@@ -2193,6 +2267,8 @@ bool ValidateLMS()
 	pass = TestLMSSpkiEncodeInvalid<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestStatefulPrivDecodeState<LMSPrivateKey<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8> >(
+		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestLMSPrivateEncodeGuard<LMS_SHA256_M32_H5, LMOTS_SHA256_N32_W8>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestLMSHSSL1SpkiEquivalence<HSS_SHA256_H5_W8_L1_Params>(
 		"LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
@@ -4995,6 +5071,8 @@ bool ValidateHSS()
 	pass = TestHSSPubDecodeState<HSS_SHA256_H5_W8_L2_Params>(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestStatefulPrivDecodeState<HSSPrivateKey<HSS_SHA256_H5_W8_L2_Params> >(
+		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
+	pass = TestHSSEncodeGuard<HSS_SHA256_H5_W8_L2_Params>(
 		"HSS[2]/LMS-SHA256-M32-H5/LMOTS-SHA256-N32-W8") && pass;
 	pass = TestHSSRFCAppendixFTC1() && pass;
 	pass = TestHSSRFCAppendixFTC2() && pass;


### PR DESCRIPTION
PQC key decoders updated the key object before validating the complete input, so malformed data could leave an existing key partly replaced. Decode into temporary storage and install the key only after validation succeeds.

Reject encoding or using unset keys. Default LMS and HSS private keys now fail Validate(), and all-zero ML-KEM and SLH-DSA key material is treated as unset. The LMS and HSS constructor checks require consumers to rebuild.

Add regression tests for decoder state, trailing data, unset-key guards and unchanged DER output.