### PR TITLE
Build shared and static libraries in one pass

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -383,6 +383,88 @@ jobs:
         test "$MK_SONAME" = "libcryptopp.so.$ABI" \
           || { echo "ERROR: GNUmakefile SONAME $MK_SONAME != libcryptopp.so.$ABI"; exit 1; }
 
+  cmake-dual:
+    name: CMake Dual Shared and Static Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (shared and static in one pass)
+      run: >
+        cmake -S . -B build/dual -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCRYPTOPP_BUILD_SHARED=ON
+        -DCRYPTOPP_BUILD_STATIC=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/dual-install
+
+    - name: Build
+      run: cmake --build build/dual -j"$(nproc)"
+
+    - name: Validate against the shared primary
+      run: |
+        cd build/dual
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+
+    - name: Install and verify both libraries and export files
+      run: |
+        INST="${{ github.workspace }}/build/dual-install"
+        cmake --install build/dual
+        find "$INST" -name 'libcryptopp.a' | grep -q . \
+          || { echo "ERROR: static archive not installed"; exit 1; }
+        find "$INST" -name 'libcryptopp.so.*' -type f | grep -q . \
+          || { echo "ERROR: shared library not installed"; exit 1; }
+        CMAKEDIR=$(dirname "$(find "$INST" -name cryptopp-modernConfig.cmake | head -1)")
+        test -f "$CMAKEDIR/cryptopp-modern-shared-targets.cmake" \
+          || { echo "ERROR: shared export file not installed"; exit 1; }
+        test -f "$CMAKEDIR/cryptopp-modern-static-targets.cmake" \
+          || { echo "ERROR: static export file not installed"; exit 1; }
+
+    - name: Build and run one consumer per component
+      run: |
+        INST="${{ github.workspace }}/build/dual-install"
+        LIBDIR=$(dirname "$(find "$INST" -name 'libcryptopp.so.*' -type f | head -1)")
+        mkdir -p dualc && cd dualc
+        cat > consumer.cpp << 'EOF'
+        #include <cryptopp/sha.h>
+        #include <cryptopp/cryptlib.h>
+        #include <vector>
+        using namespace CryptoPP;
+        int main() {
+            const byte msg[3] = {'a','b','c'};
+            SHA256 sha; std::vector<byte> d(sha.DigestSize());
+            sha.CalculateDigest(d.data(), msg, 3);
+            return d[0] == 0xba ? 0 : 1;  // digest of "abc"
+        }
+        EOF
+        cat > CMakeLists.txt << 'EOF'
+        cmake_minimum_required(VERSION 3.20)
+        project(consumer CXX)
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        find_package(cryptopp-modern REQUIRED COMPONENTS ${CRYPTOPP_COMPONENT})
+        add_executable(consumer consumer.cpp)
+        target_link_libraries(consumer PRIVATE cryptopp::cryptopp)
+        EOF
+        # The static consumer must not record a NEEDED entry for the library;
+        # the shared consumer must.
+        cmake -S . -B c-static -DCMAKE_PREFIX_PATH="$INST" -DCRYPTOPP_COMPONENT=static > /dev/null
+        cmake --build c-static > /dev/null
+        if readelf -d c-static/consumer | grep -qE 'NEEDED.*libcryptopp'; then
+          echo "ERROR: static-component consumer linked the shared library"; exit 1
+        fi
+        ./c-static/consumer
+        cmake -S . -B c-shared -DCMAKE_PREFIX_PATH="$INST" -DCRYPTOPP_COMPONENT=shared > /dev/null
+        cmake --build c-shared > /dev/null
+        readelf -d c-shared/consumer | grep -qE 'NEEDED.*libcryptopp' \
+          || { echo "ERROR: shared-component consumer is not linked against the shared library"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
+        echo "dual install consumers OK"
+
   makefile-macos-dylib:
     name: Makefile macOS dylib
     runs-on: macos-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -390,6 +390,88 @@ jobs:
         test "$MK_SONAME" = "libcryptopp.so.$ABI" \
           || { echo "ERROR: GNUmakefile SONAME $MK_SONAME != libcryptopp.so.$ABI"; exit 1; }
 
+  cmake-dual:
+    name: CMake Dual Shared and Static Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (shared and static in one pass)
+      run: >
+        cmake -S . -B build/dual -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCRYPTOPP_BUILD_SHARED=ON
+        -DCRYPTOPP_BUILD_STATIC=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/dual-install
+
+    - name: Build
+      run: cmake --build build/dual -j"$(nproc)"
+
+    - name: Validate against the shared primary
+      run: |
+        cd build/dual
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+
+    - name: Install and verify both libraries and export files
+      run: |
+        INST="${{ github.workspace }}/build/dual-install"
+        cmake --install build/dual
+        find "$INST" -name 'libcryptopp.a' | grep -q . \
+          || { echo "ERROR: static archive not installed"; exit 1; }
+        find "$INST" -name 'libcryptopp.so.*' -type f | grep -q . \
+          || { echo "ERROR: shared library not installed"; exit 1; }
+        CMAKEDIR=$(dirname "$(find "$INST" -name cryptopp-modernConfig.cmake | head -1)")
+        test -f "$CMAKEDIR/cryptopp-modern-shared-targets.cmake" \
+          || { echo "ERROR: shared export file not installed"; exit 1; }
+        test -f "$CMAKEDIR/cryptopp-modern-static-targets.cmake" \
+          || { echo "ERROR: static export file not installed"; exit 1; }
+
+    - name: Build and run one consumer per component
+      run: |
+        INST="${{ github.workspace }}/build/dual-install"
+        LIBDIR=$(dirname "$(find "$INST" -name 'libcryptopp.so.*' -type f | head -1)")
+        mkdir -p dualc && cd dualc
+        cat > consumer.cpp << 'EOF'
+        #include <cryptopp/sha.h>
+        #include <cryptopp/cryptlib.h>
+        #include <vector>
+        using namespace CryptoPP;
+        int main() {
+            const byte msg[3] = {'a','b','c'};
+            SHA256 sha; std::vector<byte> d(sha.DigestSize());
+            sha.CalculateDigest(d.data(), msg, 3);
+            return d[0] == 0xba ? 0 : 1;  // digest of "abc"
+        }
+        EOF
+        cat > CMakeLists.txt << 'EOF'
+        cmake_minimum_required(VERSION 3.20)
+        project(consumer CXX)
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        find_package(cryptopp-modern REQUIRED COMPONENTS ${CRYPTOPP_COMPONENT})
+        add_executable(consumer consumer.cpp)
+        target_link_libraries(consumer PRIVATE cryptopp::cryptopp)
+        EOF
+        # The static consumer must not record a NEEDED entry for the library;
+        # the shared consumer must.
+        cmake -S . -B c-static -DCMAKE_PREFIX_PATH="$INST" -DCRYPTOPP_COMPONENT=static > /dev/null
+        cmake --build c-static > /dev/null
+        if readelf -d c-static/consumer | grep -qE 'NEEDED.*libcryptopp'; then
+          echo "ERROR: static-component consumer linked the shared library"; exit 1
+        fi
+        ./c-static/consumer
+        cmake -S . -B c-shared -DCMAKE_PREFIX_PATH="$INST" -DCRYPTOPP_COMPONENT=shared > /dev/null
+        cmake --build c-shared > /dev/null
+        readelf -d c-shared/consumer | grep -qE 'NEEDED.*libcryptopp' \
+          || { echo "ERROR: shared-component consumer is not linked against the shared library"; exit 1; }
+        LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
+        echo "dual install consumers OK"
+
   makefile-macos-dylib:
     name: Makefile macOS dylib
     runs-on: macos-latest

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -95,10 +95,13 @@ cmake --build --preset=debug
 | `CRYPTOPP_INSTALL` | `ON` | Generate install targets |
 | `CRYPTOPP_INSTALL_CRYPTEST` | `CRYPTOPP_BUILD_TESTING` | Install cryptest.exe with its TestData and TestVectors. Set explicitly to install cryptest without the test suite, or to run the suite without installing cryptest |
 | `CRYPTOPP_BUILD_SHARED` | `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
+| `CRYPTOPP_BUILD_STATIC` | `NOT CRYPTOPP_BUILD_SHARED` | Build a static library. Enable together with `CRYPTOPP_BUILD_SHARED` to build both in one pass |
 | `CRYPTOPP_USE_OPENMP` | `OFF` | Enable OpenMP for parallel algorithms |
 | `CRYPTOPP_INCLUDE_PREFIX` | `cryptopp` | Header installation directory name |
 
 `CRYPTOPP_INSTALL_CRYPTEST` takes its default from `CRYPTOPP_BUILD_TESTING` on the first configure of a build directory. Like all CMake options the value is then cached, so changing `CRYPTOPP_BUILD_TESTING` in an existing build directory does not re-derive it; set it explicitly or start from a fresh build directory. Installing cryptest also requires `CRYPTOPP_INSTALL` (which is `ON` by default).
+
+`CRYPTOPP_BUILD_STATIC` defaults the same way from `CRYPTOPP_BUILD_SHARED`, with the same caching caveat: turning `CRYPTOPP_BUILD_SHARED` on in an existing build directory leaves the cached `CRYPTOPP_BUILD_STATIC=ON` in place and yields both libraries; start from a fresh build directory or set both options explicitly. At least one of the two must be enabled, and disabling both fails at configure time.
 
 ### x86/x64 SIMD Options
 
@@ -157,6 +160,14 @@ Windows remains static-only; requesting a shared build there fails at configure 
 
 Unix shared builds compile with default symbol visibility, so the full API is exported. When tests are enabled, cryptest links against the shared library and the validation suite runs against it.
 
+To build the shared and static libraries in one pass:
+
+```bash
+cmake -B build -DCRYPTOPP_BUILD_SHARED=ON -DCRYPTOPP_BUILD_STATIC=ON
+```
+
+The sources are compiled once per library, and the install contains both libraries and both CMake export files: the same layout that two separate configure passes produce. cryptest links the shared library in this mode.
+
 ### SONAME and ABI version
 
 The SONAME carries an ABI version that is independent of the calendar release version. It comes from the `CRYPTOPP_ABI_VERSION` macro in `include/cryptopp/config_ver.h`, is read by both the CMake and GNUmakefile builds, and increments only for ABI-incompatible changes. On Linux the installed files look like:
@@ -198,11 +209,13 @@ cmake --build build
 
 ### Component Selection
 
-You can explicitly request static or shared components (though only static is currently supported):
+You can explicitly request the static or shared library, which is the reliable way to pick one from an install that provides both:
 
 ```cmake
 find_package(cryptopp-modern REQUIRED COMPONENTS static)
 ```
+
+The two components are mutually exclusive within one `find_package` call. Without a component, the selection follows `cryptopp_SHARED_LIBS` if set, then `BUILD_SHARED_LIBS`, then whichever library the install provides (static preferred). Either way the imported target is `cryptopp::cryptopp`, and the first `find_package` call in a scope decides its type.
 
 ## Installation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,6 @@ message(STATUS "=> Project : ${PROJECT_NAME} v${cryptopp-modern_VERSION}")
 # Settable options
 # ============================================================================
 
-option(
-    CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET
-    "Use a common intermediate objects target for the static and shared library targets"
-    ON
-)
-
 if(CRYPTOPP_INCLUDE_PREFIX)
     set(CRYPTOPP_INCLUDE_PREFIX
         ${CRYPTOPP_INCLUDE_PREFIX}
@@ -203,11 +197,6 @@ include(CheckCXXCompilerFlag)
 # Test programs directory
 set(TEST_PROG_DIR ${cryptopp_SOURCE_DIR}/TestPrograms)
 set(TEST_CXX_FILE ${TEST_PROG_DIR}/test_cxx.cpp)
-
-# https://github.com/noloader/cryptopp-cmake/issues/56
-if(CMAKE_GENERATOR STREQUAL Xcode)
-    set(CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET OFF)
-endif()
 
 # ============================================================================
 # Compiler options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,26 @@ if(CRYPTOPP_BUILD_SHARED AND WIN32)
     )
 endif()
 
+# The static default follows the shared option so clean configurations keep
+# producing a single library: default gives static only, shared-only stays
+# shared only. Setting both ON builds both libraries in one pass.
+if(CRYPTOPP_BUILD_SHARED)
+    set(CRYPTOPP_DEFAULT_BUILD_STATIC OFF)
+else()
+    set(CRYPTOPP_DEFAULT_BUILD_STATIC ON)
+endif()
+option(CRYPTOPP_BUILD_STATIC
+    "Build static library"
+    "${CRYPTOPP_DEFAULT_BUILD_STATIC}"
+)
+if(NOT CRYPTOPP_BUILD_SHARED AND NOT CRYPTOPP_BUILD_STATIC)
+    message(
+        FATAL_ERROR
+        "At least one of CRYPTOPP_BUILD_SHARED or CRYPTOPP_BUILD_STATIC must "
+        "be enabled"
+    )
+endif()
+
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     set(CRYPTOPP_DEFAULT_BUILD_TYPE "Debug")
 else()
@@ -1399,6 +1419,21 @@ list(APPEND cryptopp_LIBRARY_SOURCES ${cryptopp_SOURCES})
 
 add_library(cryptopp ${cryptopp_LIBRARY_SOURCES})
 add_library(cryptopp::cryptopp ALIAS cryptopp)
+set(cryptopp_LIBRARY_TARGETS cryptopp)
+
+# In a dual build the primary target stays the shared library and the sources
+# are compiled a second time for the static archive. One object set cannot
+# serve both: the shared library exports through default visibility (GH #64)
+# while the static archive keeps the project-wide hidden preset.
+if(CRYPTOPP_BUILD_SHARED AND CRYPTOPP_BUILD_STATIC)
+    add_library(cryptopp-static STATIC ${cryptopp_LIBRARY_SOURCES})
+    set_target_properties(cryptopp-static PROPERTIES
+        OUTPUT_NAME cryptopp
+        EXPORT_NAME cryptopp
+    )
+    list(APPEND cryptopp_LIBRARY_TARGETS cryptopp-static)
+endif()
+
 # VERSION is the release version (full filename, macOS current_version).
 # SOVERSION is the ABI version (SONAME, macOS compatibility_version).
 set_target_properties(
@@ -1407,7 +1442,10 @@ set_target_properties(
         VERSION ${cryptopp-modern_VERSION}
         SOVERSION ${CRYPTOPP_ABI_VERSION}
 )
-set_target_properties(cryptopp PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(
+    ${cryptopp_LIBRARY_TARGETS}
+    PROPERTIES LINKER_LANGUAGE CXX
+)
 # CRYPTOPP_EXPORTS belongs to the legacy Windows DLL machinery and is
 # deliberately not defined for Unix shared builds, which export through
 # default visibility.
@@ -1420,29 +1458,34 @@ if(CRYPTOPP_BUILD_SHARED AND NOT WIN32)
         VISIBILITY_INLINES_HIDDEN OFF
     )
 endif()
-target_compile_definitions(
-    cryptopp
-    INTERFACE
-        $<INSTALL_INTERFACE:CRYPTOPP_INCLUDE_PREFIX=${CRYPTOPP_INCLUDE_PREFIX}>
-        ${CRYPTOPP_COMPILE_DEFINITIONS}
-)
+foreach(cryptopp_target IN LISTS cryptopp_LIBRARY_TARGETS)
+    target_compile_definitions(
+        ${cryptopp_target}
+        INTERFACE
+            $<INSTALL_INTERFACE:CRYPTOPP_INCLUDE_PREFIX=${CRYPTOPP_INCLUDE_PREFIX}>
+            ${CRYPTOPP_COMPILE_DEFINITIONS}
+    )
 
-target_include_directories(
-    cryptopp
-    PUBLIC
-        $<BUILD_INTERFACE:${cryptopp_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-)
+    target_include_directories(
+        ${cryptopp_target}
+        PUBLIC
+            $<BUILD_INTERFACE:${cryptopp_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
-    target_link_options(cryptopp PRIVATE ${CRYPTOPP_SUN_LDFLAGS})
-endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
+        target_link_options(${cryptopp_target} PRIVATE ${CRYPTOPP_SUN_LDFLAGS})
+    endif()
+endforeach()
 
 # ============================================================================
 # Static linking (recommended for portability)
 # ============================================================================
 
-# For MinGW/GCC, link statically to avoid runtime DLL dependencies
+# For MinGW/GCC, link statically to avoid runtime DLL dependencies.
+# The Windows-only blocks here and below configure just the primary target:
+# shared and dual builds are rejected on Windows at configure time, so
+# cryptopp-static never exists on this platform.
 if(MINGW OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND WIN32))
     # Static link libgcc, libstdc++, and pthreads
     target_link_options(cryptopp PRIVATE
@@ -1467,7 +1510,9 @@ if(MINGW)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     target_link_libraries(cryptopp ${CMAKE_THREAD_LIBS_INIT} -static -lpthread)
 else()
-    target_link_libraries(cryptopp ${CMAKE_THREAD_LIBS_INIT})
+    foreach(cryptopp_target IN LISTS cryptopp_LIBRARY_TARGETS)
+        target_link_libraries(${cryptopp_target} ${CMAKE_THREAD_LIBS_INIT})
+    endforeach()
 endif()
 
 # ============================================================================
@@ -1481,10 +1526,12 @@ if(CRYPTOPP_USE_OPENMP)
     find_package(OpenMP REQUIRED)
 endif()
 
-target_link_libraries(
-    cryptopp
-    $<$<BOOL:${CRYPTOPP_USE_OPENMP}>:OpenMP::OpenMP_CXX>
-)
+foreach(cryptopp_target IN LISTS cryptopp_LIBRARY_TARGETS)
+    target_link_libraries(
+        ${cryptopp_target}
+        $<$<BOOL:${CRYPTOPP_USE_OPENMP}>:OpenMP::OpenMP_CXX>
+    )
+endforeach()
 
 # ============================================================================
 # Tests
@@ -1592,36 +1639,43 @@ if(CRYPTOPP_INSTALL)
     include(ConfigFiles)
     create_module_config_files()
 
-    install(
-        TARGETS cryptopp
-        EXPORT ${TARGETS_EXPORT_NAME}
-        RUNTIME
-        COMPONENT ${runtime}
-        LIBRARY
-        COMPONENT ${runtime}
-        ARCHIVE
-        COMPONENT ${dev}
-    )
+    # Each library target installs into its own export set, so a dual build
+    # produces both cryptopp-modern-shared-targets.cmake and
+    # cryptopp-modern-static-targets.cmake in one prefix, the same layout the
+    # two-pass build installs today.
+    foreach(cryptopp_target IN LISTS cryptopp_LIBRARY_TARGETS)
+        get_target_property(cryptopp_target_type ${cryptopp_target} TYPE)
+        if(cryptopp_target_type STREQUAL "SHARED_LIBRARY")
+            set(type shared)
+        else()
+            set(type static)
+        endif()
+
+        install(
+            TARGETS ${cryptopp_target}
+            EXPORT ${TARGETS_EXPORT_NAME}_${type}
+            RUNTIME
+            COMPONENT ${runtime}
+            LIBRARY
+            COMPONENT ${runtime}
+            ARCHIVE
+            COMPONENT ${dev}
+        )
+
+        install(
+            EXPORT ${TARGETS_EXPORT_NAME}_${type}
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cryptopp-modern"
+            NAMESPACE cryptopp::
+            FILE cryptopp-modern-${type}-targets.cmake
+            COMPONENT ${dev}
+        )
+    endforeach()
 
     # Header files
     install(
         FILES ${cryptopp_HEADERS}
         COMPONENT ${dev}
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${CRYPTOPP_INCLUDE_PREFIX}"
-    )
-
-    if(CRYPTOPP_BUILD_SHARED)
-        set(type shared)
-    else()
-        set(type static)
-    endif()
-
-    install(
-        EXPORT ${TARGETS_EXPORT_NAME}
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cryptopp-modern"
-        NAMESPACE cryptopp::
-        FILE cryptopp-modern-${type}-targets.cmake
-        COMPONENT ${dev}
     )
 
     # Package configuration files
@@ -1693,4 +1747,12 @@ message(
     STATUS
     "[cryptopp-modern] Compiler options: ${CMAKE_CXX_FLAGS} ${CRYPTOPP_COMPILE_OPTIONS} ${CRYPTOPP_MSVC_COMPILE_OPTIONS}"
 )
+set(cryptopp_LIBRARY_TYPES)
+if(CRYPTOPP_BUILD_STATIC)
+    list(APPEND cryptopp_LIBRARY_TYPES static)
+endif()
+if(CRYPTOPP_BUILD_SHARED)
+    list(APPEND cryptopp_LIBRARY_TYPES shared)
+endif()
+message(STATUS "[cryptopp-modern] Libraries: ${cryptopp_LIBRARY_TYPES}")
 message(STATUS "[cryptopp-modern] Build type: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
Add `CRYPTOPP_BUILD_STATIC`, defaulting to the inverse of `CRYPTOPP_BUILD_SHARED`, so existing clean configurations still produce a single library. Enabling both builds and installs the shared and static libraries in one configure pass.

Each library has its own CMake export file, preserving the layout produced by separate builds. Installed consumers can select either with `find_package(cryptopp-modern COMPONENTS static)` or `find_package(cryptopp-modern COMPONENTS shared)`.

The sources are compiled once per library so the static archive keeps hidden visibility while the shared library keeps default symbol visibility. `cryptest` links the shared library in a dual build. Add a CI lane that builds both libraries, checks the installed files, and builds and runs a consumer against each component.

Closes #66