### PR TITLE
Fix HSS Doxygen placeholders and ML-KEM shift width

### DIFF
--- a/include/cryptopp/hss.h
+++ b/include/cryptopp/hss.h
@@ -285,8 +285,8 @@ struct HSS_Params
     }
 
     /// \brief Algorithm name
-    /// \details Uniform configurations keep the HSS[L]/<lms>/<ots> form. Mixed
-    ///  configurations list each level: HSS[L]/(<l0>,<l1>,...).
+    /// \details Uniform configurations keep the HSS[L]/{lms}/{ots} form. Mixed
+    ///  configurations list each level: HSS[L]/({l0},{l1},...).
     static std::string StaticAlgorithmName()
     {
         std::vector<std::string> names;

--- a/src/pqc/mlkem.cpp
+++ b/src/pqc/mlkem.cpp
@@ -853,7 +853,7 @@ void mlkem_decaps(byte *ss, const byte *ct, const byte *sk)
     for (unsigned int i = 0; i < InternalParams::CIPHERTEXTBYTES; i++)
         fail |= ct[i] ^ cmp[i];
     // Branchless normalization: 0 stays 0, non-zero becomes 1
-    fail = (fail | (0u - fail)) >> 31;
+    fail = (fail | (0u - fail)) >> (sizeof(fail) * 8 - 1);
 
     // FIPS 203: Implicit rejection K_bar = J(z || c) = SHAKE-256(z || c)
     byte k_bar[MLKEM_SYMBYTES];


### PR DESCRIPTION
Doxygen treated the HSS algorithm-name placeholders in hss.h as HTML tags and dropped them from the generated documentation. Use braces instead.

Derive the ML-KEM decapsulation failure-mask shift from the operand size instead of assuming 32 bits, following the existing Poly1305 code. No behaviour change.