### PR TITLE
Honour BUILD_SHARED_LIBS when selecting the library type

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -465,6 +465,54 @@ jobs:
         LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
         echo "dual install consumers OK"
 
+  cmake-build-shared-libs:
+    name: CMake BUILD_SHARED_LIBS Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (BUILD_SHARED_LIBS only, tests on)
+      run: >
+        cmake -S . -B build/bsl -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SHARED_LIBS=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/bsl-install
+
+    - name: Build
+      run: cmake --build build/bsl -j"$(nproc)"
+
+    - name: Validate against the shared library
+      run: |
+        cd build/bsl
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+
+    - name: Install and verify the library type
+      run: |
+        # The standard variable alone must select the shared library. The
+        # SONAME, symlink and consumer checks live in the cmake-shared lane.
+        INST="${{ github.workspace }}/build/bsl-install"
+        cmake --install build/bsl
+        find "$INST" -name 'libcryptopp.so.*' -type f | grep -q . \
+          || { echo "ERROR: shared library not installed"; exit 1; }
+        if find "$INST" -name 'libcryptopp.a' | grep -q .; then
+          echo "ERROR: static archive installed with BUILD_SHARED_LIBS=ON"; exit 1
+        fi
+
+    - name: Check precedence (configure only)
+      run: |
+        # An explicit CRYPTOPP_BUILD_SHARED wins over BUILD_SHARED_LIBS, and a
+        # defined-but-OFF BUILD_SHARED_LIBS keeps the static default.
+        cmake -S . -B build/prec-off -G Ninja -DCRYPTOPP_BUILD_TESTING=OFF           -DBUILD_SHARED_LIBS=ON -DCRYPTOPP_BUILD_SHARED=OFF > /dev/null
+        grep -q '^CRYPTOPP_BUILD_SHARED:BOOL=OFF$' build/prec-off/CMakeCache.txt           || { echo "ERROR: explicit CRYPTOPP_BUILD_SHARED=OFF did not win"; exit 1; }
+        cmake -S . -B build/prec-bsl-off -G Ninja -DCRYPTOPP_BUILD_TESTING=OFF           -DBUILD_SHARED_LIBS=OFF > /dev/null
+        grep -q '^CRYPTOPP_BUILD_SHARED:BOOL=OFF$' build/prec-bsl-off/CMakeCache.txt           || { echo "ERROR: BUILD_SHARED_LIBS=OFF did not keep the static default"; exit 1; }
+        echo "precedence OK"
+
   makefile-macos-dylib:
     name: Makefile macOS dylib
     runs-on: macos-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -472,6 +472,54 @@ jobs:
         LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
         echo "dual install consumers OK"
 
+  cmake-build-shared-libs:
+    name: CMake BUILD_SHARED_LIBS Test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install Ninja
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+    - name: Configure (BUILD_SHARED_LIBS only, tests on)
+      run: >
+        cmake -S . -B build/bsl -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SHARED_LIBS=ON
+        -DCRYPTOPP_BUILD_TESTING=ON
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/bsl-install
+
+    - name: Build
+      run: cmake --build build/bsl -j"$(nproc)"
+
+    - name: Validate against the shared library
+      run: |
+        cd build/bsl
+        LD_LIBRARY_PATH="$PWD" ./cryptest.exe v
+
+    - name: Install and verify the library type
+      run: |
+        # The standard variable alone must select the shared library. The
+        # SONAME, symlink and consumer checks live in the cmake-shared lane.
+        INST="${{ github.workspace }}/build/bsl-install"
+        cmake --install build/bsl
+        find "$INST" -name 'libcryptopp.so.*' -type f | grep -q . \
+          || { echo "ERROR: shared library not installed"; exit 1; }
+        if find "$INST" -name 'libcryptopp.a' | grep -q .; then
+          echo "ERROR: static archive installed with BUILD_SHARED_LIBS=ON"; exit 1
+        fi
+
+    - name: Check precedence (configure only)
+      run: |
+        # An explicit CRYPTOPP_BUILD_SHARED wins over BUILD_SHARED_LIBS, and a
+        # defined-but-OFF BUILD_SHARED_LIBS keeps the static default.
+        cmake -S . -B build/prec-off -G Ninja -DCRYPTOPP_BUILD_TESTING=OFF           -DBUILD_SHARED_LIBS=ON -DCRYPTOPP_BUILD_SHARED=OFF > /dev/null
+        grep -q '^CRYPTOPP_BUILD_SHARED:BOOL=OFF$' build/prec-off/CMakeCache.txt           || { echo "ERROR: explicit CRYPTOPP_BUILD_SHARED=OFF did not win"; exit 1; }
+        cmake -S . -B build/prec-bsl-off -G Ninja -DCRYPTOPP_BUILD_TESTING=OFF           -DBUILD_SHARED_LIBS=OFF > /dev/null
+        grep -q '^CRYPTOPP_BUILD_SHARED:BOOL=OFF$' build/prec-bsl-off/CMakeCache.txt           || { echo "ERROR: BUILD_SHARED_LIBS=OFF did not keep the static default"; exit 1; }
+        echo "precedence OK"
+
   makefile-macos-dylib:
     name: Makefile macOS dylib
     runs-on: macos-latest

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -94,12 +94,14 @@ cmake --build --preset=debug
 | `CRYPTOPP_BUILD_TESTING` | `ON` | Build the test executable (cryptest.exe) and register the CTest suite |
 | `CRYPTOPP_INSTALL` | `ON` | Generate install targets |
 | `CRYPTOPP_INSTALL_CRYPTEST` | `CRYPTOPP_BUILD_TESTING` | Install cryptest.exe with its TestData and TestVectors. Set explicitly to install cryptest without the test suite, or to run the suite without installing cryptest |
-| `CRYPTOPP_BUILD_SHARED` | `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
+| `CRYPTOPP_BUILD_SHARED` | `BUILD_SHARED_LIBS` if defined, else `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
 | `CRYPTOPP_BUILD_STATIC` | `NOT CRYPTOPP_BUILD_SHARED` | Build a static library. Enable together with `CRYPTOPP_BUILD_SHARED` to build both in one pass |
 | `CRYPTOPP_USE_OPENMP` | `OFF` | Enable OpenMP for parallel algorithms |
 | `CRYPTOPP_INCLUDE_PREFIX` | `cryptopp` | Header installation directory name |
 
 `CRYPTOPP_INSTALL_CRYPTEST` takes its default from `CRYPTOPP_BUILD_TESTING` on the first configure of a build directory. Like all CMake options the value is then cached, so changing `CRYPTOPP_BUILD_TESTING` in an existing build directory does not re-derive it; set it explicitly or start from a fresh build directory. Installing cryptest also requires `CRYPTOPP_INSTALL` (which is `ON` by default).
+
+`CRYPTOPP_BUILD_SHARED` takes its default from the standard `BUILD_SHARED_LIBS` variable when that is defined, so `-DBUILD_SHARED_LIBS=ON` on its own builds the shared library, with the same first-configure caching. An explicit `CRYPTOPP_BUILD_SHARED` takes precedence, which lets a project that sets `BUILD_SHARED_LIBS` for its own targets keep this library static. Building both libraries still requires `CRYPTOPP_BUILD_STATIC=ON` alongside either shared selector.
 
 `CRYPTOPP_BUILD_STATIC` defaults the same way from `CRYPTOPP_BUILD_SHARED`, with the same caching caveat: turning `CRYPTOPP_BUILD_SHARED` on in an existing build directory leaves the cached `CRYPTOPP_BUILD_STATIC=ON` in place and yields both libraries; start from a fresh build directory or set both options explicitly. At least one of the two must be enabled, and disabling both fails at configure time.
 
@@ -156,7 +158,7 @@ cmake -B build -DCRYPTOPP_BUILD_SHARED=ON
 cmake --build build
 ```
 
-Windows remains static-only; requesting a shared build there fails at configure time. The old Windows DLL was the FIPS module, which is abandoned, and its hand-maintained export set is gone.
+Windows remains static-only; `CRYPTOPP_BUILD_SHARED=ON` or `BUILD_SHARED_LIBS=ON` fails at configure time. The old Windows DLL was the FIPS module, which is abandoned, and its hand-maintained export set is gone.
 
 Unix shared builds compile with default symbol visibility, so the full API is exported. When tests are enabled, cryptest links against the shared library and the validation suite runs against it.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,13 +118,26 @@ option(CRYPTOPP_INSTALL "Generate the install target for this project." ON)
 # Windows DLL builds are not supported. The old DLL was the FIPS one, which is
 # abandoned, and its hand-maintained export set is gone. Shared builds are
 # allowed on Unix-like platforms, where the library exports the full API.
-option(CRYPTOPP_BUILD_SHARED "Build shared library" OFF)
+#
+# The default follows BUILD_SHARED_LIBS when the caller defined it, so the
+# standard variable selects the library type on its own. An explicit
+# CRYPTOPP_BUILD_SHARED still takes precedence.
+set(CRYPTOPP_DEFAULT_BUILD_SHARED OFF)
+if(DEFINED BUILD_SHARED_LIBS)
+    set(CRYPTOPP_DEFAULT_BUILD_SHARED "${BUILD_SHARED_LIBS}")
+endif()
+option(CRYPTOPP_BUILD_SHARED
+    "Build shared library"
+    "${CRYPTOPP_DEFAULT_BUILD_SHARED}"
+)
 if(CRYPTOPP_BUILD_SHARED AND WIN32)
     message(
         FATAL_ERROR
         "Shared (DLL) builds are not supported on Windows. The old DLL was the "
         "FIPS one, which is abandoned. Build a static library on Windows, or "
-        "build shared on a non-Windows target."
+        "build shared on a non-Windows target. BUILD_SHARED_LIBS=ON also "
+        "selects a shared build; set CRYPTOPP_BUILD_SHARED=OFF to keep the "
+        "library static when BUILD_SHARED_LIBS is on for other targets."
     )
 endif()
 


### PR DESCRIPTION
Configuring with only `-DBUILD_SHARED_LIBS=ON` produced a static library because `CRYPTOPP_BUILD_SHARED` overwrote it. `CRYPTOPP_BUILD_SHARED` now takes its default from `BUILD_SHARED_LIBS` when that variable is defined, so the usual CMake convention selects the shared library.

An explicit `CRYPTOPP_BUILD_SHARED` still takes precedence, and `CRYPTOPP_BUILD_STATIC` can be enabled alongside either shared selector to build both libraries. The default and first-configure caching behaviour are documented in `CMAKE.md`.

A new CI lane configures with `BUILD_SHARED_LIBS` alone and checks that the shared library, not the static archive, is installed.

Refs: #66