### PR TITLE
Fix the include path for ARM feature probes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ function(check_compile_link_option opt var prog)
         COMMAND_SUCCESS
         ${CMAKE_BINARY_DIR}
         ${prog}
+        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${cryptopp_SOURCE_DIR}/include"
         COMPILE_DEFINITIONS ${definitions}
     )
     if(COMMAND_SUCCESS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -128,7 +128,7 @@ endif
 
 # TCOMMAND is used for just about all tests. Make will lazy-evaluate
 # the variables when executed by $(shell $(TCOMMAND) ...).
-TCOMMAND = $(CXX) -I. $(TCXXFLAGS) $(TEXTRA) $(ZOPT) $(TOPT) $(TPROG) -o $(TOUT)
+TCOMMAND = $(CXX) -I. -Iinclude $(TCXXFLAGS) $(TEXTRA) $(ZOPT) $(TOPT) $(TPROG) -o $(TOUT)
 
 # Fixup AIX
 ifeq ($(IS_AIX),1)


### PR DESCRIPTION
The Phase 2 layout moved arm_simd.h under include/cryptopp, but the CMake and GNUmakefile probes did not search that directory. CRC32 and PMULL detection therefore failed in clean ARM builds, disabling both hardware paths.