### PR TITLE
Enable hardware AES, SHA and PMULL on Apple arm64

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -113,7 +113,32 @@ jobs:
       run: cmake --build build/ci-macos -j"$(sysctl -n hw.ncpu)"
 
     - name: Run validation tests
-      run: ./build/ci-macos/cryptest.exe v
+      run: |
+        set -o pipefail
+        ./build/ci-macos/cryptest.exe v | tee cryptest-v.log
+
+    - name: Check Apple arm64 hardware feature detection
+      if: runner.arch == 'ARM64'
+      run: |
+        FEATURES=$(grep -o 'hasASIMD == .*' cryptest-v.log | head -1)
+        echo "$FEATURES"
+        # Every 64-bit Apple core implements these.
+        for f in hasASIMD hasAES hasPMULL hasSHA1 hasSHA2; do
+          echo "$FEATURES" | grep -q "$f == 1" || { echo "ERROR: $f not detected"; exit 1; }
+        done
+        # The optional extensions must agree with the OS. The first key that
+        # exists wins; the second names are the pre-macOS 12 spellings.
+        check() {
+          flag=$1; shift
+          expected=0
+          for key in "$@"; do
+            if value=$(sysctl -n "$key" 2>/dev/null); then expected=$value; break; fi
+          done
+          echo "$FEATURES" | grep -q "$flag == $expected" || { echo "ERROR: $flag disagrees with the kernel ($expected)"; exit 1; }
+        }
+        check hasCRC32 hw.optional.armv8_crc32
+        check hasSHA3 hw.optional.arm.FEAT_SHA3 hw.optional.armv8_2_sha3
+        check hasSHA512 hw.optional.arm.FEAT_SHA512 hw.optional.armv8_2_sha512
 
     - name: Run test vectors
       run: ./build/ci-macos/cryptest.exe tv all

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,7 +120,32 @@ jobs:
       run: cmake --build build/ci-macos -j"$(sysctl -n hw.ncpu)"
 
     - name: Run validation tests
-      run: ./build/ci-macos/cryptest.exe v
+      run: |
+        set -o pipefail
+        ./build/ci-macos/cryptest.exe v | tee cryptest-v.log
+
+    - name: Check Apple arm64 hardware feature detection
+      if: runner.arch == 'ARM64'
+      run: |
+        FEATURES=$(grep -o 'hasASIMD == .*' cryptest-v.log | head -1)
+        echo "$FEATURES"
+        # Every 64-bit Apple core implements these.
+        for f in hasASIMD hasAES hasPMULL hasSHA1 hasSHA2; do
+          echo "$FEATURES" | grep -q "$f == 1" || { echo "ERROR: $f not detected"; exit 1; }
+        done
+        # The optional extensions must agree with the OS. The first key that
+        # exists wins; the second names are the pre-macOS 12 spellings.
+        check() {
+          flag=$1; shift
+          expected=0
+          for key in "$@"; do
+            if value=$(sysctl -n "$key" 2>/dev/null); then expected=$value; break; fi
+          done
+          echo "$FEATURES" | grep -q "$flag == $expected" || { echo "ERROR: $flag disagrees with the kernel ($expected)"; exit 1; }
+        }
+        check hasCRC32 hw.optional.armv8_crc32
+        check hasSHA3 hw.optional.arm.FEAT_SHA3 hw.optional.armv8_2_sha3
+        check hasSHA512 hw.optional.arm.FEAT_SHA512 hw.optional.armv8_2_sha512
 
     - name: Run test vectors
       run: ./build/ci-macos/cryptest.exe tv all

--- a/src/core/cpu.cpp
+++ b/src/core/cpu.cpp
@@ -226,31 +226,8 @@ public:
 		}
 		else if (machine.find("arm64") != std::string::npos)
 		{
-			// M1 machine?
-			std::string brand;
-			size_t size = 32;
-
-			// Supply an oversized buffer, and avoid
-			// an extra call to sysctlbyname.
-			brand.resize(size);
-			if (sysctlbyname("machdep.cpu.brand_string", &brand[0], &size, NULL, 0) == 0 && size > 0)
-			{
-				if (brand[size-1] == '\0')
-					size--;
-				brand.resize(size);
-			}
-
-			if (brand == "Apple M1")
-			{
-				m_device = Mac;
-				m_arch = ARMV82;
-			}
-			else
-			{
-				// ???
-				m_device = 0;
-				m_arch = ARMV8;
-			}
+			m_device = Mac;
+			m_arch = ARMV8;
 		}
 		else
 		{
@@ -304,49 +281,18 @@ void GetAppleMachineInfo(unsigned int& device, unsigned int& version, unsigned i
 	arch = info.Arch();
 }
 
-inline bool IsAppleMachineARM32()
+#if defined(__aarch64__)
+// Apple publishes one hw.optional sysctl per optional Armv8 extension.
+// A missing key means the feature is absent or the OS predates the key,
+// and both cases answer false. The FEAT_ names date from macOS 12 and
+// iOS 15; the older armv8_ names are still published and cover macOS 11.
+inline bool IsAppleFeaturePresent(const char* name)
 {
-	static unsigned int arch;
-	if (arch == 0)
-	{
-		unsigned int unused;
-		GetAppleMachineInfo(unused, unused, arch);
-	}
-	return arch == AppleMachineInfo::ARM32;
+	int value = 0;
+	size_t size = sizeof(value);
+	return sysctlbyname(name, &value, &size, NULL, 0) == 0 && value != 0;
 }
-
-inline bool IsAppleMachineARMv8()
-{
-	static unsigned int arch;
-	if (arch == 0)
-	{
-		unsigned int unused;
-		GetAppleMachineInfo(unused, unused, arch);
-	}
-	return arch >= AppleMachineInfo::ARMV8;
-}
-
-inline bool IsAppleMachineARMv82()
-{
-	static unsigned int arch;
-	if (arch == 0)
-	{
-		unsigned int unused;
-		GetAppleMachineInfo(unused, unused, arch);
-	}
-	return arch >= AppleMachineInfo::ARMV82;
-}
-
-inline bool IsAppleMachineARMv83()
-{
-	static unsigned int arch;
-	if (arch == 0)
-	{
-		unsigned int unused;
-		GetAppleMachineInfo(unused, unused, arch);
-	}
-	return arch >= AppleMachineInfo::ARMV83;
-}
+#endif  // __aarch64__
 
 #endif  // __APPLE__
 
@@ -908,8 +854,7 @@ inline bool CPU_QueryNEON()
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
 	// Core feature set for Aarch32 and Aarch64.
-	if (IsAppleMachineARMv8())
-		return true;
+	return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	// Windows 10 ARM64 is only supported on Armv8a and above
 	if (IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE) != 0)
@@ -935,8 +880,7 @@ inline bool CPU_QueryCRC32()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_CRC32) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
+	if (IsAppleFeaturePresent("hw.optional.armv8_crc32"))
 		return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) != 0)
@@ -962,9 +906,9 @@ inline bool CPU_QueryPMULL()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_PMULL) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
-		return true;
+	// Present on every 64-bit Apple core; see the Apple entries in
+	// LLVM's AArch64Processors.td.
+	return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
@@ -989,9 +933,9 @@ inline bool CPU_QueryAES()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_AES) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
-		return true;
+	// Present on every 64-bit Apple core; see the Apple entries in
+	// LLVM's AArch64Processors.td.
+	return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
@@ -1016,9 +960,9 @@ inline bool CPU_QuerySHA1()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_SHA1) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
-		return true;
+	// Present on every 64-bit Apple core; see the Apple entries in
+	// LLVM's AArch64Processors.td.
+	return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
@@ -1043,9 +987,9 @@ inline bool CPU_QuerySHA256()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_SHA2) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
-		return true;
+	// Present on every 64-bit Apple core; see the Apple entries in
+	// LLVM's AArch64Processors.td.
+	return true;
 #elif defined(_WIN32) && defined(_M_ARM64)
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
@@ -1077,8 +1021,8 @@ inline bool CPU_QuerySHA3()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_SHA3) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
+	if (IsAppleFeaturePresent("hw.optional.arm.FEAT_SHA3") ||
+		IsAppleFeaturePresent("hw.optional.armv8_2_sha3"))
 		return true;
 #endif
 	return false;
@@ -1108,8 +1052,8 @@ inline bool CPU_QuerySHA512()
 	if ((getauxval(AT_HWCAP2) & HWCAP2_SHA512) != 0)
 		return true;
 #elif defined(__APPLE__) && defined(__aarch64__)
-	// M1 processor
-	if (IsAppleMachineARMv82())
+	if (IsAppleFeaturePresent("hw.optional.arm.FEAT_SHA512") ||
+		IsAppleFeaturePresent("hw.optional.armv8_2_sha512"))
 		return true;
 #endif
 	return false;


### PR DESCRIPTION
On Apple arm64, hardware AES, SHA-1, SHA-256 and PMULL dispatch was limited to systems whose CPU brand string was exactly "Apple M1". Other Apple Silicon Macs and arm64 iOS devices therefore fell back to software for those operations.

Treat those features as present on Apple arm64, and query Apple's `hw.optional` sysctls for optional CRC32, SHA-3 and SHA-512 support. The macOS CMake lane now checks the detected features against the runner.

Refs: weidai11/cryptopp#1373