### PR TITLE
Use the configured include directory in CMake exports

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -490,6 +490,34 @@ jobs:
         LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
         echo "dual install consumers OK"
 
+    - name: Install with split prefixes and run one consumer per component
+      run: |
+        # Libraries under prefix A, headers under prefix B, so A/include does not
+        # exist. The exported include directory must follow CMAKE_INSTALL_INCLUDEDIR.
+        # The prefixes sit outside the checkout: CMake rejects an exported include
+        # directory that lies inside the source tree.
+        A="$RUNNER_TEMP/split-a"
+        B="$RUNNER_TEMP/split-b"
+        cmake -S . -B build/dual-split -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCRYPTOPP_BUILD_SHARED=ON \
+          -DCRYPTOPP_BUILD_STATIC=ON \
+          -DCRYPTOPP_BUILD_TESTING=OFF \
+          -DCMAKE_INSTALL_PREFIX="$A" \
+          -DCMAKE_INSTALL_LIBDIR="$A/lib" \
+          -DCMAKE_INSTALL_INCLUDEDIR="$B/include" > /dev/null
+        cmake --build build/dual-split -j"$(nproc)" > /dev/null
+        cmake --install build/dual-split > /dev/null
+        test ! -e "$A/include" || { echo "ERROR: headers installed under the library prefix"; exit 1; }
+        test -f "$B/include/cryptopp/cryptlib.h" || { echo "ERROR: headers not installed under the include prefix"; exit 1; }
+        cd dualc
+        for comp in static shared; do
+          cmake -S . -B "s-$comp" -DCMAKE_PREFIX_PATH="$A;$B" -DCRYPTOPP_COMPONENT=$comp > /dev/null
+          cmake --build "s-$comp" > /dev/null
+          LD_LIBRARY_PATH="$A/lib" "./s-$comp/consumer"
+        done
+        echo "split-prefix consumers OK"
+
   cmake-build-shared-libs:
     name: CMake BUILD_SHARED_LIBS Test
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -497,6 +497,34 @@ jobs:
         LD_LIBRARY_PATH="$LIBDIR" ./c-shared/consumer
         echo "dual install consumers OK"
 
+    - name: Install with split prefixes and run one consumer per component
+      run: |
+        # Libraries under prefix A, headers under prefix B, so A/include does not
+        # exist. The exported include directory must follow CMAKE_INSTALL_INCLUDEDIR.
+        # The prefixes sit outside the checkout: CMake rejects an exported include
+        # directory that lies inside the source tree.
+        A="$RUNNER_TEMP/split-a"
+        B="$RUNNER_TEMP/split-b"
+        cmake -S . -B build/dual-split -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCRYPTOPP_BUILD_SHARED=ON \
+          -DCRYPTOPP_BUILD_STATIC=ON \
+          -DCRYPTOPP_BUILD_TESTING=OFF \
+          -DCMAKE_INSTALL_PREFIX="$A" \
+          -DCMAKE_INSTALL_LIBDIR="$A/lib" \
+          -DCMAKE_INSTALL_INCLUDEDIR="$B/include" > /dev/null
+        cmake --build build/dual-split -j"$(nproc)" > /dev/null
+        cmake --install build/dual-split > /dev/null
+        test ! -e "$A/include" || { echo "ERROR: headers installed under the library prefix"; exit 1; }
+        test -f "$B/include/cryptopp/cryptlib.h" || { echo "ERROR: headers not installed under the include prefix"; exit 1; }
+        cd dualc
+        for comp in static shared; do
+          cmake -S . -B "s-$comp" -DCMAKE_PREFIX_PATH="$A;$B" -DCRYPTOPP_COMPONENT=$comp > /dev/null
+          cmake --build "s-$comp" > /dev/null
+          LD_LIBRARY_PATH="$A/lib" "./s-$comp/consumer"
+        done
+        echo "split-prefix consumers OK"
+
   cmake-build-shared-libs:
     name: CMake BUILD_SHARED_LIBS Test
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ if(
 endif()
 
 include(CheckCXXCompilerFlag)
+include(GNUInstallDirs)
 
 # Test programs directory
 set(TEST_PROG_DIR ${cryptopp_SOURCE_DIR}/TestPrograms)
@@ -1485,7 +1486,7 @@ foreach(cryptopp_target IN LISTS cryptopp_LIBRARY_TARGETS)
         ${cryptopp_target}
         PUBLIC
             $<BUILD_INTERFACE:${cryptopp_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
@@ -1551,9 +1552,6 @@ endforeach()
 # ============================================================================
 # Tests
 # ============================================================================
-
-# CRYPTOPP_DATA_DIR below depends on CMAKE_INSTALL_FULL_DATAROOTDIR.
-include(GNUInstallDirs)
 
 if(
     CRYPTOPP_BUILD_TESTING


### PR DESCRIPTION
The installed targets always pointed to include under the install prefix, ignoring CMAKE_INSTALL_INCLUDEDIR. This broke find_package when headers were installed elsewhere.

Checked split installs with both shared and static consumers.