### PR TITLE
Fix pkg-config and CTest configuration handling

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -156,11 +156,8 @@ jobs:
     - name: Build
       run: cmake --build build/ci-windows --config Release
 
-    - name: Run validation tests
-      run: ./build/ci-windows/Release/cryptest.exe v
-
-    - name: Run test vectors
-      run: ./build/ci-windows/Release/cryptest.exe tv all
+    - name: Run the test suite through CTest
+      run: ctest --test-dir build/ci-windows -C Release -V --no-tests=error
 
   cmake-windows-arm64:
     # ARM64 Windows host with the Visual Studio generator, covering issue #43:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,11 +163,8 @@ jobs:
     - name: Build
       run: cmake --build build/ci-windows --config Release
 
-    - name: Run validation tests
-      run: ./build/ci-windows/Release/cryptest.exe v
-
-    - name: Run test vectors
-      run: ./build/ci-windows/Release/cryptest.exe tv all
+    - name: Run the test suite through CTest
+      run: ctest --test-dir build/ci-windows -C Release -V --no-tests=error
 
   cmake-windows-arm64:
     # ARM64 Windows host with the Visual Studio generator, covering issue #43:

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -70,7 +70,7 @@ The project includes `CMakePresets.json` with pre-configured build configuration
 | `install-test` | Ninja | Release | For testing installation |
 | `ci-linux` | Ninja | Release | CI configuration for Linux |
 | `ci-macos` | Ninja | Release | CI configuration for macOS |
-| `ci-windows` | Visual Studio 17 2022 | Release | CI configuration for Windows |
+| `ci-windows` | Visual Studio 17 2022 | - | CI configuration for Windows |
 
 ### Using Presets
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,10 @@ endif()
 # Testing
 # ------------------------------------------------------------------------------
 
-if(CRYPTOPP_BUILD_TESTING)
-    enable_testing()
-endif()
+# Always enabled so that turning CRYPTOPP_BUILD_TESTING off in an existing
+# build directory regenerates an empty test list instead of leaving the
+# previous one behind. Test registration stays conditional.
+enable_testing()
 
 # ------------------------------------------------------------------------------
 # Build the library
@@ -1605,7 +1606,7 @@ if(CRYPTOPP_BUILD_TESTING)
         NAME cryptopp-modern-build_cryptest
         COMMAND
             "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target cryptest
-            --config ${CMAKE_BUILD_TYPE}
+            --config $<CONFIG>
     )
     set_tests_properties(
         cryptopp-modern-build_cryptest
@@ -1701,7 +1702,7 @@ if(CRYPTOPP_INSTALL)
     )
     install(
         FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc
+            ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libcryptopp.pc
             ${CMAKE_CURRENT_BINARY_DIR}/cryptopp-modern.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
         COMPONENT ${dev}
@@ -1768,4 +1769,8 @@ if(CRYPTOPP_BUILD_SHARED)
     list(APPEND cryptopp_LIBRARY_TYPES shared)
 endif()
 message(STATUS "[cryptopp-modern] Libraries: ${cryptopp_LIBRARY_TYPES}")
-message(STATUS "[cryptopp-modern] Build type: ${CMAKE_BUILD_TYPE}")
+if(CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "[cryptopp-modern] Configurations: ${CMAKE_CONFIGURATION_TYPES}")
+else()
+    message(STATUS "[cryptopp-modern] Build type: ${CMAKE_BUILD_TYPE}")
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,7 +98,6 @@
       "description": "Configuration for Windows CI builds",
       "inherits": "msvc",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
         "CRYPTOPP_BUILD_TESTING": "ON"
       }
     },

--- a/cmake/ConfigFiles.cmake
+++ b/cmake/ConfigFiles.cmake
@@ -20,15 +20,10 @@ endfunction()
 function(_module_pkgconfig_files)
     message(STATUS "[cryptopp-modern] Generating pkgconfig files")
 
-    # DEBUG_POSTFIX applies to the uppercased build type, so match it the same way.
-    string(TOUPPER "${CMAKE_BUILD_TYPE}" _cryptopp_build_type)
-    if(_cryptopp_build_type STREQUAL "DEBUG")
-        get_target_property(target_debug_postfix cryptopp DEBUG_POSTFIX)
-        if("${target_debug_postfix}" MATCHES "-NOTFOUND$")
-            set(target_debug_postfix "")
-        endif()
-    endif()
-    set(MODULE_LINK_LIBS "-lcryptopp${target_debug_postfix}")
+    # The link name is resolved per configuration at generate time, so a
+    # postfix or OUTPUT_NAME on the target is reflected without inspecting
+    # the build type here.
+    set(MODULE_LINK_LIBS "-l$<TARGET_FILE_BASE_NAME:cryptopp>")
 
     # Keep relative pkg-config paths relative to ${prefix}, but pass absolute
     # GNUInstallDirs overrides through unchanged.
@@ -41,11 +36,17 @@ function(_module_pkgconfig_files)
     endforeach()
 
     # Primary file is named libcryptopp.pc to match upstream Crypto++, so
-    # `pkg-config libcryptopp` keeps working for existing consumers.
+    # `pkg-config libcryptopp` keeps working for existing consumers. Paths and
+    # the version are substituted now; the link name is written per
+    # configuration by file(GENERATE).
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.pc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc
+        ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc.configured
         @ONLY
+    )
+    file(GENERATE
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libcryptopp.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/libcryptopp.pc.configured
     )
 
     # Alias for consumers that adopted the fork's cryptopp-modern name; it


### PR DESCRIPTION
The pkg-config file now uses the target's output name and postfix for each configuration. This fixes Debug postfix handling in multi-config builds and honours `OUTPUT_NAME` and non-Debug postfixes.

The CTest build fixture now uses the selected configuration, fixing the `msvc` preset flow. Turning `CRYPTOPP_BUILD_TESTING` off in an existing build directory clears the previous test list. The Windows CI job now runs the suite through CTest.
