### PR TITLE
Guard the starting level in HSS subtree rebuilds

### DIFF
--- a/src/pqc/lms.cpp
+++ b/src/pqc/lms.cpp
@@ -1584,6 +1584,11 @@ void HSSSigner<HSS_PARAMS>::BuildSubtreeChain(
 {
     using namespace LMS_Internal;
 
+    // Level 0 is the root and has no parent.
+    CRYPTOPP_ASSERT(fromLevel >= 1);
+    if (fromLevel == 0)
+        throw InvalidArgument("HSSSigner: invalid subtree level");
+
     LevelTable<HSS_PARAMS> levels;
 
     for (unsigned int level = fromLevel; level < HSS_PARAMS::L; level++)


### PR DESCRIPTION
GCC reports `-Warray-bounds` warnings in `HSSSigner::BuildSubtreeChain` for the two single-level HSS parameter sets, breaking builds with `-Werror=array-bounds`.

The helper accesses the parent as `level - 1`. Reject a starting level of 0 with `InvalidArgument` before constructing the level table. Neither caller passes 0, so existing signing behaviour is unchanged.

Checked with GCC 13.3 and 16.1 at `-O2` and `-O3` using `-Wall -Wextra -Werror=array-bounds`. Full `cryptest v` passed.

Closes #97
