### PR TITLE
Fix CMake feature probes under -Werror

### DIFF
--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -30,6 +30,42 @@ jobs:
     - name: Run test vectors
       run: ./build/ci-linux/cryptest.exe tv all
 
+    - name: Check feature probes under -Werror (configure only)
+      run: |
+        # A -Werror in the incoming flags, plain, configuration-specific or
+        # oddly delimited, and quoted paths must not change the detected
+        # features, and the probe-only -w must not reach the library build.
+        mkdir -p "$RUNNER_TEMP/probe include" "$RUNNER_TEMP/probe -Werror include"
+        : > "$RUNNER_TEMP/probe -Werror include/header.h"
+        check() {
+          dir=$1; shift
+          cmake -S . -B "build/$dir" -DCRYPTOPP_BUILD_TESTING=OFF "$@" > /dev/null
+          for feature in SSE2 SSE41 AVX512; do
+            grep -q "^CRYPTOPP_HAVE_$feature:INTERNAL=1$" "build/$dir/CMakeCache.txt" \
+              || { echo "ERROR: $dir: $feature not detected"; exit 1; }
+          done
+          ninja -C "build/$dir" -t commands cryptopp > "build/$dir/commands.txt"
+          grep -q -- '-Werror' "build/$dir/commands.txt" \
+            || { echo "ERROR: $dir: -Werror missing from the build"; exit 1; }
+          if grep -q -- ' -w ' "build/$dir/commands.txt"; then
+            echo "ERROR: $dir: probe-only -w reached the build"; exit 1
+          fi
+        }
+        check probe-werror -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS="-Wall -Werror"
+        check probe-config-werror -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -Werror" \
+          -DCMAKE_TRY_COMPILE_CONFIGURATION=Release
+        check probe-multi-config -G "Ninja Multi-Config" \
+          -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_CXX_FLAGS_DEBUG="-g -Werror"
+        check probe-quoted -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=-I\"$RUNNER_TEMP/probe include\" -Wall -Werror"
+        check probe-include -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=-include \"$RUNNER_TEMP/probe -Werror include/header.h\" -Wall -Werror"
+        check probe-tab -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=$(printf -- '-Wall\t-Werror')"
+        echo "feature probes OK"
+
   cmake-linux-gcc14:
     name: CMake Linux (GCC 14)
     runs-on: ubuntu-24.04

--- a/.github/workflows/branch-build-and-test.yml
+++ b/.github/workflows/branch-build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y ninja-build
 
     - name: Configure
-      run: cmake --preset=ci-linux
+      run: cmake --preset=ci-linux -DCRYPTOPP_WERROR=ON
 
     - name: Build
       run: cmake --build build/ci-linux -j"$(nproc)"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,42 @@ jobs:
     - name: Run test vectors
       run: ./build/ci-linux/cryptest.exe tv all
 
+    - name: Check feature probes under -Werror (configure only)
+      run: |
+        # A -Werror in the incoming flags, plain, configuration-specific or
+        # oddly delimited, and quoted paths must not change the detected
+        # features, and the probe-only -w must not reach the library build.
+        mkdir -p "$RUNNER_TEMP/probe include" "$RUNNER_TEMP/probe -Werror include"
+        : > "$RUNNER_TEMP/probe -Werror include/header.h"
+        check() {
+          dir=$1; shift
+          cmake -S . -B "build/$dir" -DCRYPTOPP_BUILD_TESTING=OFF "$@" > /dev/null
+          for feature in SSE2 SSE41 AVX512; do
+            grep -q "^CRYPTOPP_HAVE_$feature:INTERNAL=1$" "build/$dir/CMakeCache.txt" \
+              || { echo "ERROR: $dir: $feature not detected"; exit 1; }
+          done
+          ninja -C "build/$dir" -t commands cryptopp > "build/$dir/commands.txt"
+          grep -q -- '-Werror' "build/$dir/commands.txt" \
+            || { echo "ERROR: $dir: -Werror missing from the build"; exit 1; }
+          if grep -q -- ' -w ' "build/$dir/commands.txt"; then
+            echo "ERROR: $dir: probe-only -w reached the build"; exit 1
+          fi
+        }
+        check probe-werror -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS="-Wall -Werror"
+        check probe-config-werror -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -Werror" \
+          -DCMAKE_TRY_COMPILE_CONFIGURATION=Release
+        check probe-multi-config -G "Ninja Multi-Config" \
+          -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_CXX_FLAGS_DEBUG="-g -Werror"
+        check probe-quoted -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=-I\"$RUNNER_TEMP/probe include\" -Wall -Werror"
+        check probe-include -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=-include \"$RUNNER_TEMP/probe -Werror include/header.h\" -Wall -Werror"
+        check probe-tab -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          "-DCMAKE_CXX_FLAGS=$(printf -- '-Wall\t-Werror')"
+        echo "feature probes OK"
+
   cmake-linux-gcc14:
     name: CMake Linux (GCC 14)
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y ninja-build
 
     - name: Configure
-      run: cmake --preset=ci-linux
+      run: cmake --preset=ci-linux -DCRYPTOPP_WERROR=ON
 
     - name: Build
       run: cmake --build build/ci-linux -j"$(nproc)"

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -97,6 +97,7 @@ cmake --build --preset=debug
 | `CRYPTOPP_BUILD_SHARED` | `BUILD_SHARED_LIBS` if defined, else `OFF` | Build a shared library (Unix-like platforms only; not supported on Windows) |
 | `CRYPTOPP_BUILD_STATIC` | `NOT CRYPTOPP_BUILD_SHARED` | Build a static library. Enable together with `CRYPTOPP_BUILD_SHARED` to build both in one pass |
 | `CRYPTOPP_USE_OPENMP` | `OFF` | Enable OpenMP for parallel algorithms |
+| `CRYPTOPP_WERROR` | `OFF` | Treat compiler warnings as errors (GCC and Clang) |
 | `CRYPTOPP_INCLUDE_PREFIX` | `cryptopp` | Header installation directory name |
 
 `CRYPTOPP_INSTALL_CRYPTEST` takes its default from `CRYPTOPP_BUILD_TESTING` on the first configure of a build directory. Like all CMake options the value is then cached, so changing `CRYPTOPP_BUILD_TESTING` in an existing build directory does not re-derive it; set it explicitly or start from a fresh build directory. Installing cryptest also requires `CRYPTOPP_INSTALL` (which is `ON` by default).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,12 @@ function(check_compile_link_option opt var prog)
     endif()
 
     message(STATUS "[cryptopp-modern] Performing Test ${var}")
+    # The probes ask whether the compiler accepts an instruction set. Silence
+    # warnings for the probe compile so a -Werror in the incoming flags cannot
+    # turn a warning in the probe source into a failed test.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+    endif()
     set(definitions ${CRYPTOPP_COMPILE_DEFINITIONS})
     if(MSVC)
         list(APPEND definitions ${CRYPTOPP_MSVC_COMPILE_DEFINITIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option(CRYPTOPP_USE_OPENMP
     "Enable OpenMP to parallelize some of the algorithms. Note that this isn't always faster, see https://www.cryptopp.com/wiki/OpenMP"
     OFF
 )
+option(CRYPTOPP_WERROR "Treat compiler warnings as errors (GCC and Clang)" OFF)
 
 # IA-32 options
 option(CRYPTOPP_DISABLE_ASM "Disable ASM" OFF)
@@ -561,6 +562,10 @@ if(
     AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12"
 )
     list(APPEND CRYPTOPP_COMPILE_OPTIONS "-fno-devirtualize")
+endif()
+
+if(CRYPTOPP_WERROR AND CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+    list(APPEND CRYPTOPP_COMPILE_OPTIONS "-Werror")
 endif()
 # ------------------------------------------------------------------------------
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,7 +79,8 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CRYPTOPP_BUILD_TESTING": "ON"
+        "CRYPTOPP_BUILD_TESTING": "ON",
+        "CMAKE_CXX_FLAGS": "-Wall"
       }
     },
     {


### PR DESCRIPTION
Warnings in the probe sources caused `-Wall -Werror` builds to fail the SSE4.1 and AVX-512 checks. Compile the probes with `-w` so warnings do not affect feature detection.

Enable `-Wall` in the Linux CMake jobs and add `CRYPTOPP_WERROR`, enabled for the main GCC 13 job. Regression checks cover configuration flags, quoted paths and tabs, and confirm that `-w` stays out of the library build.

Checked with GCC 13 and Clang 18. The GCC 13 build passed all validation tests.
