### PR TITLE
Fix CTest fixture registration and AVX-512 fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,6 +774,8 @@ if(
                 list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "CRYPTOPP_DISABLE_AVX=1")
             elseif(NOT avx2_flag)
                 list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "CRYPTOPP_DISABLE_AVX2=1")
+            elseif(NOT avx512_flag)
+                list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "CRYPTOPP_DISABLE_AVX512=1")
             endif()
             if(NOT shani_flag)
                 list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "CRYPTOPP_DISABLE_SHANI=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1635,6 +1635,7 @@ if(CRYPTOPP_BUILD_TESTING)
         cryptopp-modern-cryptest
         PROPERTIES
             FIXTURES_REQUIRED cryptest-build
+            RESOURCE_LOCK cryptest-data
             LABELS "cryptopp-modern;cryptopp-cryptest"
     )
 
@@ -1646,7 +1647,8 @@ if(CRYPTOPP_BUILD_TESTING)
     set_tests_properties(
         cryptopp-modern-cryptest-extensive
         PROPERTIES
-            FIXTURES_CLEANUP cryptest-build
+            FIXTURES_REQUIRED cryptest-build
+            RESOURCE_LOCK cryptest-data
             LABELS "cryptopp-modern;cryptopp-cryptest"
     )
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -491,6 +491,10 @@ ifeq ($(DETECT_FEATURES),1)
       else
       ifeq ($(AVX2_FLAG),)
         CRYPTOPP_CPPFLAGS += -DCRYPTOPP_DISABLE_AVX2
+      else
+      ifeq ($(AVX512_FLAG),)
+        CRYPTOPP_CPPFLAGS += -DCRYPTOPP_DISABLE_AVX512
+      endif # AVX512
       endif # AVX2
       endif # AVX
       # SHANI independent of AVX per GH #1045


### PR DESCRIPTION
`cryptest tv all` was registered as fixture cleanup. It now requires the build fixture, so selecting it alone also builds `cryptest`, and selecting only `cryptest v` no longer pulls it in. Both tests share a resource lock because they write the same `cryptest.dat` file.

CMake and the GNUmakefile now define `CRYPTOPP_DISABLE_AVX512` when the AVX-512 probe fails. Previously, they dropped the compiler flag but still compiled the AVX-512 code, causing intrinsic target mismatch errors.

Checked parallel CTest runs, test selection and the AVX-512 fallback in both build systems.
