### PR TITLE
Bound the LM-OTS hash length before sizing buffers

### DIFF
--- a/src/pqc/lms.cpp
+++ b/src/pqc/lms.cpp
@@ -136,6 +136,10 @@ void lmots_sign(byte *sig, const byte *message, size_t messageLen,
     const unsigned int ls = params.ls;
     const unsigned int u = params.u;
 
+    // Bound n before sizing the hash and checksum buffers.
+    if (n == 0 || n > SHA256::DIGESTSIZE)
+        throw InvalidArgument("LM-OTS: invalid hash output length");
+
     u32str(sig, params.type_id);
     byte *sig_C = sig + 4;
     byte *sig_y = sig + 4 + n;
@@ -196,6 +200,10 @@ void lmots_compute_candidate_key(byte *Kc, const byte *sig,
     const unsigned int ls = params.ls;
     const unsigned int u = params.u;
     const unsigned int maxJ = (1u << w) - 1;
+
+    // Bound n before sizing the hash and checksum buffers.
+    if (n == 0 || n > SHA256::DIGESTSIZE)
+        throw InvalidArgument("LM-OTS: invalid hash output length");
 
     // Parse signature: type(4) + C(n) + y[0..p-1](p*n)
     const byte *sig_C = sig + 4;


### PR DESCRIPTION
GCC 11 on ARM-32 reports `-Wstringop-overflow` warnings for the LM-OTS checksum-buffer copies, breaking builds with `-Werror`. The compiler cannot see the bound on `params.n` imposed by the supported parameter sets.

Reject zero and lengths above the SHA-256 digest size in `lmots_sign` and `lmots_compute_candidate_key`, before pointer arithmetic or copies. Supported signing and verification behaviour is unchanged. No public API or ABI changes.

Checked ARM-32 GCC 11.5 builds, native validation and vector suites, and direct helper calls with invalid lengths.

Closes #105
